### PR TITLE
Make ptipython respect more config changes

### DIFF
--- a/ptpython/ipython.py
+++ b/ptpython/ipython.py
@@ -225,6 +225,24 @@ def initialize_extensions(shell, extensions):
                     "Error in loading extension: %s" % ext +
                     "\nCheck your config files in %s" % ipy_utils.path.get_ipython_dir())
                 shell.showtraceback()
+  
+def run_exec_lines(shell, exec_lines):
+    """
+        Partial copy of  run_exec_lines code from IPython.core.shellapp .
+    """
+    try:
+        iter(exec_lines)
+    except TypeError:
+        pass
+    else:
+        try:
+            for line in exec_lines:
+                try:
+                    shell.run_cell(line, store_history=False)
+                except:
+                    shell.showtraceback()
+        except:
+            shell.showtraceback()
 
 
 def embed(**kwargs):
@@ -240,4 +258,5 @@ def embed(**kwargs):
         kwargs['config'] = config
     shell = InteractiveShellEmbed.instance(**kwargs)
     initialize_extensions(shell, config['InteractiveShellApp']['extensions'])
+    run_exec_lines(shell, config['InteractiveShellApp']['exec_lines'])
     shell(header=header, stack_depth=2, compile_flags=compile_flags)


### PR DESCRIPTION
Currently ptipython loads extension modules, but does not execute lines from the config file.

For example, I was trying to initialize the autoreload app from ipython, 
    c.InteractiveShellApp.extensions = ['autoreload']
    c.InteractiveShellApp.exec_lines = ['%autoreload 2']
    c.InteractiveShellApp.exec_lines.append('print("Warning: disable autoreload in ipython_config.py to improve performance.")')

The first line worked, while the other two were ignored.

This allows ipython configuration to support use cases mentioned in:
https://github.com/jonathanslenders/ptpython/issues/36
https://github.com/jonathanslenders/ptpython/issues/65

I'm sure there are a lot more cases where the ptipython interface is slightly different from the ipython one, but I'm not sure what the plan for convergence is, so for now I tried to follow around the same pattern as initialize_extensions.
