### PR TITLE
implement XDG Base Directory specification

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,7 @@ navigation mode.
 Configuration
 *************
 
-It is possible to create a ``~/.ptpython/config.py`` file to customize the configuration.
+It is possible to create a ``$XDG_CONFIG_HOME/ptpython/config.py`` file to customize the configuration.
 
 Have a look at this example to see what is possible:
 `config.py <https://github.com/jonathanslenders/ptpython/blob/master/examples/ptpython_config/config.py>`_

--- a/examples/ptpython_config/config.py
+++ b/examples/ptpython_config/config.py
@@ -1,7 +1,7 @@
 """
 Configuration example for ``ptpython``.
 
-Copy this file to ~/.ptpython/config.py
+Copy this file to $XDG_CONFIG_HOME/ptpython/config.py
 """
 from __future__ import unicode_literals
 from prompt_toolkit.filters import ViInsertMode

--- a/ptpython/entry_points/run_ptipython.py
+++ b/ptpython/entry_points/run_ptipython.py
@@ -9,11 +9,12 @@ Usage:
 
 Options:
     --vi                     : Use Vi keybindings instead of Emacs bindings.
-    --config-dir=<directory> : Pass config directory. By default '~/.ptpython/'.
+    --config-dir=<directory> : Pass config directory. By default '$XDG_CONFIG_HOME/ptpython'.
     -i, --interactive=<filename> : Start interactive shell after executing this file.
 """
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, unicode_literals, print_function
 
+import appdirs
 import docopt
 import os
 import six
@@ -24,11 +25,23 @@ def run(user_ns=None):
     a = docopt.docopt(__doc__)
 
     vi_mode = bool(a['--vi'])
-    config_dir = os.path.expanduser(a['--config-dir'] or '~/.ptpython/')
 
-    # Create config directory.
-    if not os.path.isdir(config_dir):
-        os.mkdir(config_dir)
+    config_dir = appdirs.user_config_dir('ptpython', 'Jonathan Slenders')
+    data_dir = appdirs.user_data_dir('ptpython', 'Jonathan Slenders')
+
+    if a['--config-dir']:
+        # Override config_dir.
+        config_dir = os.path.expanduser(a['--config-dir'])
+    else:
+        # Warn about the legacy directory.
+        legacy_dir = os.path.expanduser('~/.ptpython')
+        if os.path.isdir(legacy_dir):
+            print('{0} is deprecated, migrate your configuration to {1}'.format(legacy_dir, config_dir))
+
+    # Create directories.
+    for d in (config_dir, data_dir):
+        if not os.path.isdir(d) and not os.path.islink(d):
+            os.mkdir(d)
 
     # If IPython is not available, show message and exit here with error status
     # code.
@@ -89,7 +102,7 @@ def run(user_ns=None):
 
         # Run interactive shell.
         embed(vi_mode=vi_mode,
-              history_filename=os.path.join(config_dir, 'history'),
+              history_filename=os.path.join(data_dir, 'history'),
               configure=configure,
               user_ns=user_ns,
               title='IPython REPL (ptipython)')

--- a/ptpython/entry_points/run_ptpython.py
+++ b/ptpython/entry_points/run_ptpython.py
@@ -9,14 +9,15 @@ Usage:
 
 Options:
     --vi                         : Use Vi keybindings instead of Emacs bindings.
-    --config-dir=<directory>     : Pass config directory. By default '~/.ptpython/'.
+    --config-dir=<directory>     : Pass config directory. By default '$XDG_CONFIG_HOME/ptpython'.
     -i, --interactive=<filename> : Start interactive shell after executing this file.
 
 Other environment variables:
 PYTHONSTARTUP: file executed on interactive startup (no default)
 """
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, unicode_literals, print_function
 
+import appdirs
 import docopt
 import os
 import six
@@ -29,11 +30,23 @@ def run():
     a = docopt.docopt(__doc__)
 
     vi_mode = bool(a['--vi'])
-    config_dir = os.path.expanduser(a['--config-dir'] or '~/.ptpython/')
 
-    # Create config directory.
-    if not os.path.isdir(config_dir):
-        os.mkdir(config_dir)
+    config_dir = appdirs.user_config_dir('ptpython', 'Jonathan Slenders')
+    data_dir = appdirs.user_data_dir('ptpython', 'Jonathan Slenders')
+
+    if a['--config-dir']:
+        # Override config_dir.
+        config_dir = os.path.expanduser(a['--config-dir'])
+    else:
+        # Warn about the legacy directory.
+        legacy_dir = os.path.expanduser('~/.ptpython')
+        if os.path.isdir(legacy_dir):
+            print('{0} is deprecated, migrate your configuration to {1}'.format(legacy_dir, config_dir))
+
+    # Create directories.
+    for d in (config_dir, data_dir):
+        if not os.path.isdir(d) and not os.path.islink(d):
+            os.mkdir(d)
 
     # Startup path
     startup_paths = []
@@ -69,7 +82,7 @@ def run():
 
         import __main__
         embed(vi_mode=vi_mode,
-              history_filename=os.path.join(config_dir, 'history'),
+              history_filename=os.path.join(data_dir, 'history'),
               configure=configure,
               locals=__main__.__dict__,
               globals=__main__.__dict__,

--- a/ptpython/python_input.py
+++ b/ptpython/python_input.py
@@ -314,7 +314,7 @@ class PythonInput(object):
     def add_key_binding(self):
         """
         Shortcut for adding new key bindings.
-        (Mostly useful for a .ptpython/config.py file, that receives
+        (Mostly useful for a config.py file, that receives
         a PythonInput/Repl instance as input.)
 
         ::

--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -240,7 +240,7 @@ def enable_deprecation_warnings():
                             module='__main__')
 
 
-def run_config(repl, config_file='~/.ptpython/config.py'):
+def run_config(repl, config_file):
     """
     Execute REPL config file.
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     long_description=long_description,
     packages=find_packages('.'),
     install_requires = [
+        'appdirs',
         'docopt',
         'jedi>=0.9.0',
         'prompt_toolkit>=2.0.6,<2.1.0',


### PR DESCRIPTION
I accidentally deleted the fork I had for #183, so I'm recreating it.

* Use the appdirs module.
* Print a warning if the legacy ~/.ptpython directory is detected.
* Resolves #63.
* Resolves #132.