### PR TITLE
Fix embed asyncio

### DIFF
--- a/examples/asyncio-python-embed.py
+++ b/examples/asyncio-python-embed.py
@@ -38,10 +38,11 @@ def interactive_shell():
     counter variable.
     """
     print('You should be able to read and update the "counter[0]" variable from this shell.')
-    yield from embed(globals=globals(), return_asyncio_coroutine=True, patch_stdout=True)
-
-    # Stop the loop when quitting the repl. (Ctrl-D press.)
-    loop.stop()
+    try:
+        yield from embed(globals=globals(), return_asyncio_coroutine=True, patch_stdout=True)
+    except EOFError:
+        # Stop the loop when quitting the repl. (Ctrl-D press.)
+        loop.stop()
 
 
 def main():

--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -20,6 +20,7 @@ from prompt_toolkit.utils import DummyContext
 from prompt_toolkit.shortcuts import set_title, clear_title
 from prompt_toolkit.shortcuts import print_formatted_text
 from prompt_toolkit.formatted_text import PygmentsTokens
+from prompt_toolkit.patch_stdout import patch_stdout as patch_stdout_context
 
 from .python_input import PythonInput
 from .eventloop import inputhook
@@ -331,7 +332,7 @@ def embed(globals=None, locals=None, configure=None,
     app = repl.app
 
     # Start repl.
-    patch_context = app.patch_stdout_context() if patch_stdout else DummyContext()
+    patch_context = patch_stdout_context() if patch_stdout else DummyContext()
 
     if return_asyncio_coroutine: # XXX
         def coroutine():

--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -343,14 +343,8 @@ def embed(globals=None, locals=None, configure=None,
                         while True:
                             yield next(iterator)
                     except StopIteration as exc:
-                        if exc.args:
-                            text = exc.args[0]
-                        else:
-                            text = None
-                    try:
-                        repl._process_text(text)
-                    except EOFError:
-                        return
+                        text = exc.args[0]
+                    repl._process_text(text)
         return coroutine()
     else:
         with patch_context:


### PR DESCRIPTION
This includes a fix for the `embed` repl. Previously, the application would fail because the application does not have a `patch_stdout_context` method. 

This code further complicates the `embed` method to maintain syntax compatibility with python2. I **strongly** recommend refactoring `prompt_toolkit` and `ptpython` to remove python2 compatibility. It will greatly improve maintainability going forward. If possibly, I would generally recommend moving to >=3.5 or more for asynchronous code clarity.

Closes #288 and is an continuation of #287 