### PR TITLE
change PythonRepl._process_text to use input text instead of ignoring it

### DIFF
--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -76,8 +76,7 @@ class PythonRepl(PythonInput):
         if self.terminal_title:
             clear_title()
 
-    def _process_text(self, text):
-        line = self.default_buffer.text
+    def _process_text(self, line):
 
         if line and not line.isspace():
             try:


### PR DESCRIPTION
Right now, `PythonRepl._process_text` takes text input, but it then ignores that text completely. In my development environment, I set it up to run `_process_text` and added the ability to use `await`. However, this feature fails because `_process_text` ignores the input text and uses the buffer instead. Alternatively, the method should not even take in text. I also recommend making this method public, but that is certainly debatable.