### PR TITLE
Fix style

### DIFF
--- a/ptpython/python_input.py
+++ b/ptpython/python_input.py
@@ -338,7 +338,6 @@ class PythonInput(object):
         Install a new code color scheme.
         """
         assert isinstance(name, six.text_type)
-        assert isinstance(style_dict, dict)
 
         self.code_styles[name] = style_dict
 
@@ -356,7 +355,6 @@ class PythonInput(object):
         Install a new UI color scheme.
         """
         assert isinstance(name, six.text_type)
-        assert isinstance(style_dict, dict)
 
         self.ui_styles[name] = style_dict
 


### PR DESCRIPTION
Styling appears to demand a prompt_toolkit.styles.Style rather than a dict, and
works with one, but the assert demands a dict.