### PR TITLE
Fix NameError when using example config

### DIFF
--- a/examples/ptpython_config/config.py
+++ b/examples/ptpython_config/config.py
@@ -62,8 +62,8 @@ def configure(repl):
     repl.complete_while_typing = True
 
     # Fuzzy and dictionary completion.
-    self.enable_fuzzy_completion = False
-    self.enable_dictionary_completion = False
+    repl.enable_fuzzy_completion = False
+    repl.enable_dictionary_completion = False
 
     # Vi mode.
     repl.vi_mode = False


### PR DESCRIPTION
After copying the example config file and running `ptpython`, I am met
with a stacktrace:

```
$ ptpython
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/ptpython/repl.py", line 276, in run_config
    namespace['configure'](repl)
  File "/home/ryan/.config//ptpython/config.py", line 65, in configure
    self.enable_fuzzy_completion = False
NameError: name 'self' is not defined

Press ENTER to continue...
```

The config file is then ignored.

This change restores functionality with the example config.