### PR TITLE
Bugfix/config example fixes

### DIFF
--- a/examples/ptpython_config/config.py
+++ b/examples/ptpython_config/config.py
@@ -1,7 +1,9 @@
 """
 Configuration example for ``ptpython``.
 
-Copy this file to ~/.ptpython/config.py
+Copy this file to ~/.ptpython/config.py on windows use 
+`os.path.expanduser("~/.ptpython/config.py")` to find the 
+correct location.
 """
 from __future__ import unicode_literals
 from prompt_toolkit.filters import ViInsertMode

--- a/examples/ptpython_config/config.py
+++ b/examples/ptpython_config/config.py
@@ -62,8 +62,8 @@ def configure(repl):
     repl.complete_while_typing = True
 
     # Fuzzy and dictionary completion.
-    self.enable_fuzzy_completion = False
-    self.enable_dictionary_completion = False
+    repl.enable_fuzzy_completion = False
+    repl.enable_dictionary_completion = False
 
     # Vi mode.
     repl.vi_mode = False


### PR DESCRIPTION
The settings for "Fuzzy and dictionary completion." refer to self rather than repl.

Added some comments to help windows users find the location of the config file.