### PR TITLE
Retain backwards compatibility

### DIFF
--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -268,7 +268,7 @@ def enable_deprecation_warnings() -> None:
     warnings.filterwarnings("default", category=DeprecationWarning, module="__main__")
 
 
-def run_config(repl: PythonInput, config_file: str) -> None:
+def run_config(repl: PythonInput, config_file: str="~/.ptpython/config.py") -> None:
     """
     Execute REPL config file.
 

--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -268,7 +268,7 @@ def enable_deprecation_warnings() -> None:
     warnings.filterwarnings("default", category=DeprecationWarning, module="__main__")
 
 
-def run_config(repl: PythonInput, config_file: str="~/.ptpython/config.py") -> None:
+def run_config(repl: PythonInput, config_file: str = "~/.ptpython/config.py") -> None:
     """
     Execute REPL config file.
 


### PR DESCRIPTION
Some other libraries (e.g. issue #388) rely on the previous signature of this function. This change makes the function signature more flexible so current and older usages don't break.