### PR TITLE
Improve PythonRepl.run_async() method

### DIFF
--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -94,9 +94,23 @@ class PythonRepl(PythonInput):
             clear_title()
 
     async def run_async(self) -> None:
+        if self.terminal_title:
+            set_title(self.terminal_title)
+
         while True:
-            text = await self.app.run_async()
-            self._process_text(text)
+            # Run the UI.
+            try:
+                text = await self.app.run_async()
+            except EOFError:
+                return
+            except KeyboardInterrupt:
+                # Abort - try again.
+                self.default_buffer.document = Document()
+            else:
+                self._process_text(text)
+
+        if self.terminal_title:
+            clear_title()
 
     def _process_text(self, line: str) -> None:
 


### PR DESCRIPTION
I noticed that the `PythonRepl.run_async()` method is not equivalent to `PythonRepl.run()`, even though it should behave the same according to the code in `ptpython.repl.embed`:

https://github.com/prompt-toolkit/ptpython/blob/89017ba158ed1d95319233fa5aedf3931c3b8b77/ptpython/repl.py#L369-L378

This is part of my work on https://github.com/prompt-toolkit/python-prompt-toolkit/pull/1150

Note: f1c4906 is entirely optional