### PR TITLE
Add config options related to Vi input mode

### DIFF
--- a/examples/ptpython_config/config.py
+++ b/examples/ptpython_config/config.py
@@ -120,7 +120,7 @@ def configure(repl):
     repl.enable_syntax_highlighting = True
 
     # Get into Vi navigation mode at startup
-    repl.vi_start_in_nav_mode = False
+    repl.vi_start_in_navigation_mode = False
 
     # Preserve last used Vi input mode between main loop iterations
     repl.vi_keep_last_used_mode = False

--- a/examples/ptpython_config/config.py
+++ b/examples/ptpython_config/config.py
@@ -119,6 +119,12 @@ def configure(repl):
     # Syntax.
     repl.enable_syntax_highlighting = True
 
+    # Get into Vi navigation mode at startup
+    repl.vi_start_in_nav_mode = False
+
+    # Preserve last used Vi input mode between main loop iterations
+    repl.vi_keep_last_used_mode = False
+
     # Install custom colorscheme named 'my-colorscheme' and use it.
     """
     repl.install_ui_colorscheme('my-colorscheme', Style.from_dict(_custom_ui_colorscheme))

--- a/ptpython/python_input.py
+++ b/ptpython/python_input.py
@@ -301,7 +301,7 @@ class PythonInput:
         self._get_signatures_thread_running: bool = False
 
         # Get into Vi navigation mode at startup
-        self.vi_start_in_nav_mode: bool = False
+        self.vi_start_in_navigation_mode: bool = False
 
         # Preserve last used Vi input mode between main loop iterations
         self.vi_keep_last_used_mode: bool = False

--- a/ptpython/python_input.py
+++ b/ptpython/python_input.py
@@ -300,6 +300,12 @@ class PythonInput:
         # (Never run more than one at the same time.)
         self._get_signatures_thread_running: bool = False
 
+        # Get into Vi navigation mode at startup
+        self.vi_start_in_nav_mode: bool = False
+
+        # Preserve last used Vi input mode between main loop iterations
+        self.vi_keep_last_used_mode: bool = False
+
         self.style_transformation = merge_style_transformations(
             [
                 ConditionalStyleTransformation(

--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -377,10 +377,6 @@ def embed(
     if configure:
         configure(repl)
 
-    # Set Vi input mode
-    if repl.vi_start_in_navigation_mode:
-        repl.app.vi_state.input_mode = InputMode.NAVIGATION
-
     # Start repl.
     patch_context: ContextManager = patch_stdout_context() if patch_stdout else DummyContext()
 

--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -90,7 +90,7 @@ class PythonRepl(PythonInput):
                 if self.vi_keep_last_used_mode:
                     self.app.vi_state.input_mode = last_input_mode
 
-                if not self.vi_keep_last_used_mode and self.vi_start_in_nav_mode:
+                if not self.vi_keep_last_used_mode and self.vi_start_in_navigation_mode:
                     self.app.vi_state.input_mode = InputMode.NAVIGATION
 
             # Run the UI.
@@ -378,7 +378,7 @@ def embed(
         configure(repl)
 
     # Set Vi input mode
-    if repl.vi_start_in_nav_mode:
+    if repl.vi_start_in_navigation_mode:
         repl.app.vi_state.input_mode = InputMode.NAVIGATION
 
     # Start repl.


### PR DESCRIPTION
Setting `vi_start_in_nav_mode` to `True` enables `NAVIGATION` mode on startup.
The issue is that due to the current behaviour of `ViState.reset()` input mode
gets resetted back to `INSERT` on the every iteration of the main loop. In order
to at one hand to provide the user with desired behaviour and on the other hand
doesn't introduce breaking changes the other option `vi_keep_last_used_mode` was
introduced which sets `input_mode` to the state observed before reset.

`vi_keep_last_used_mode` can be useful even with `vi_start_in_nav_mode` set to
`False` in the case the user prefer to start in `INSERT` mode but still wants to
maintain the last mode he was in.

In the case of `vi_keep_last_used_mode` set to `False` and
`vi_start_in_nav_mode` to `True` `NAVIGATION` mode is set on every iteration the
same way `INSERT` was set before this commit.

Fixes #258.

Commit rebased and modified by Jonathan Slenders.