### PR TITLE
Fix exit confirmation.

### DIFF
--- a/ptpython/key_bindings.py
+++ b/ptpython/key_bindings.py
@@ -187,7 +187,12 @@ def load_python_bindings(python_input):
         Override Control-D exit, to ask for confirmation.
         """
         if python_input.confirm_exit:
+            # Show exit confirmation and focus it (focusing is important for
+            # making sure the default buffer key bindings are not active).
             python_input.show_exit_confirmation = True
+            python_input.app.layout.focus(
+                python_input.ptpython_layout.exit_confirmation
+            )
         else:
             event.app.exit(exception=EOFError)
 
@@ -279,6 +284,7 @@ def load_confirm_exit_bindings(python_input):
         Cancel exit.
         """
         python_input.show_exit_confirmation = False
+        python_input.app.layout.focus_previous()
 
     return bindings
 

--- a/ptpython/layout.py
+++ b/ptpython/layout.py
@@ -501,7 +501,7 @@ def show_sidebar_button_info(python_input: "PythonInput") -> Container:
     )
 
 
-def exit_confirmation(
+def create_exit_confirmation(
     python_input: "PythonInput", style="class:exit-confirmation"
 ) -> Container:
     """
@@ -511,7 +511,7 @@ def exit_confirmation(
     def get_text_fragments() -> StyleAndTextTuples:
         # Show "Do you really want to exit?"
         return [
-            (style, "\n %s ([y]/n)" % python_input.exit_message),
+            (style, "\n %s ([y]/n) " % python_input.exit_message),
             ("[SetCursorPosition]", ""),
             (style, "  \n"),
         ]
@@ -520,8 +520,8 @@ def exit_confirmation(
 
     return ConditionalContainer(
         content=Window(
-            FormattedTextControl(get_text_fragments), style=style
-        ),  # , has_focus=visible)),
+            FormattedTextControl(get_text_fragments, focusable=True), style=style
+        ),
         filter=visible,
     )
 
@@ -635,6 +635,7 @@ class PtPythonLayout:
             )
 
         sidebar = python_sidebar(python_input)
+        self.exit_confirmation = create_exit_confirmation(python_input)
 
         root_container = HSplit(
             [
@@ -680,7 +681,7 @@ class PtPythonLayout:
                                         Float(
                                             left=2,
                                             bottom=1,
-                                            content=exit_confirmation(python_input),
+                                            content=self.exit_confirmation,
                                         ),
                                         Float(
                                             bottom=0,


### PR DESCRIPTION
Before, the exit confirmation was not focused. Which meant that key bindings of
the main buffer were still active. If we are in Vi mode, that meant that there
was a key binding for the ("y", "y") already, which caused the handling of "y"
to be delayed (it was not marked as eager). This fix will focus the exit
confirmation and avoid further interference of buffer key bindings.