### PR TITLE
Cursor shape dependent on vi editing mode

### DIFF
--- a/ptpython/python_input.py
+++ b/ptpython/python_input.py
@@ -234,6 +234,9 @@ class PythonInput:
         self.enable_system_bindings: bool = True
         self.enable_input_validation: bool = True
         self.enable_auto_suggest: bool = False
+        self.enable_modal_cursor: bool = True
+        self.ttimeoutlen: float = 0.01
+        self.timeoutlen: float = 0.5
         self.enable_mouse_support: bool = False
         self.enable_history_search: bool = False  # When True, like readline, going
         # back in history will filter the


### PR DESCRIPTION
This pull request implements vim mode-dependent changes in cursor shape.

The cursor shape is 
- beam in Insert mode:
![image](https://user-images.githubusercontent.com/13444106/94983250-0adf8080-050f-11eb-917b-763fe2f9f628.png)
- block in Nav (Normal) mode
![image](https://user-images.githubusercontent.com/13444106/94983252-13d05200-050f-11eb-8978-26308b40048d.png)
- underscore in Replace mode
![image](https://user-images.githubusercontent.com/13444106/94983256-1df25080-050f-11eb-886e-8800354bc7d8.png)

The code is based on [a prompt_toolkit issue](https://github.com/prompt-toolkit/python-prompt-toolkit/issues/192#issuecomment-557800620).

I put the cursor code in `ptpython/key_bindings.py`, because the imported classes are from `prompt_toolkit`'s `key_binding` module. This may be a stretch, but pressing certain keys (e.g. escape, i, a, e, R) can switch modes and change the cursor shape.

This PR only effects vi mode.

Currently, this feature is enabled by default, but it can be disabled using by adding 
```python
repl.enable_modal_cursor = False
```
to `config.py`. 

To install a version of ptpython with the modal cursor, run the line below.

`python -m pip install git+https://github.com/mskar/ptpython.git@vim_cursor`