### PR TITLE
Add top level awaitables

### DIFF
--- a/ptpython/python_input.py
+++ b/ptpython/python_input.py
@@ -4,9 +4,9 @@ This can be used for creation of Python REPLs.
 """
 import __future__
 
+from ast import PyCF_ALLOW_TOP_LEVEL_AWAIT
 from asyncio import get_event_loop
 from functools import partial
-import ast
 from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar
 
 from prompt_toolkit.application import Application, get_app
@@ -379,7 +379,7 @@ class PythonInput:
         Give the current compiler flags by looking for _Feature instances
         in the globals.
         """
-        flags = ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
+        flags = PyCF_ALLOW_TOP_LEVEL_AWAIT
 
         for value in self.get_globals().values():
             try:

--- a/ptpython/python_input.py
+++ b/ptpython/python_input.py
@@ -6,6 +6,7 @@ import __future__
 
 from asyncio import get_event_loop
 from functools import partial
+import ast
 from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar
 
 from prompt_toolkit.application import Application, get_app
@@ -378,7 +379,7 @@ class PythonInput:
         Give the current compiler flags by looking for _Feature instances
         in the globals.
         """
-        flags = 0
+        flags = ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
 
         for value in self.get_globals().values():
             try:

--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -9,11 +9,11 @@ Utility for creating a Python repl.
 """
 import asyncio
 import builtins
+import inspect
 import os
 import sys
 import traceback
 import warnings
-import inspect
 from typing import Any, Callable, ContextManager, Dict, Optional
 
 from prompt_toolkit.document import Document

--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -48,15 +48,19 @@ async def interruptable(co):
 
     def signal_handler(signal, frame):
         loop = interrupted.get_loop()
+
         async def _finish():
             interrupted.set_result(True)
+
         asyncio.run_coroutine_threadsafe(_finish(), loop=loop)
 
     orig_handler = signal.getsignal(signal.SIGINT)
     signal.signal(signal.SIGINT, signal_handler)
 
     task = asyncio.create_task(co)
-    done, pending = await asyncio.wait([task, interrupted], return_when=asyncio.FIRST_COMPLETED)
+    done, pending = await asyncio.wait(
+        [task, interrupted], return_when=asyncio.FIRST_COMPLETED
+    )
     signal.signal(signal.SIGINT, orig_handler)
 
     if interrupted in done:
@@ -213,7 +217,7 @@ class PythonRepl(PythonInput):
 
             # If not a valid `eval` expression, run using `exec` instead.
             except SyntaxError:
-                code = compile_with_flags(line, "single")
+                code = compile_with_flags(line, "exec")
                 result = eval(code, self.get_globals(), self.get_locals())
 
                 if code.co_flags & inspect.CO_COROUTINE:


### PR DESCRIPTION
I needed this feature #99 for using `embed` with an existing event loop in a project.

Comparing this approach with IPython or `asyncio.__main__` or aioconsole:
- IPython runs top level awaits in their own eventloop
- `asyncio.__main__` runs a different thread for executing code
- aioconsole does not use the `ast.PyCF_ALLOW_TOP_LEVEL_AWAIT` flag

This approach would run awaitables in the same event loop as the repl. This means interrupting awaitables is not consistently possible. As the interrupt might trigger the eventloop and then the repl to exit.
However this way it was possible to use `embed` with an existing eventloop and without running the repl itself in a different thread.
If interrupting awaitables consistently is a must I might be tempted to try out running ptpython in a different thread than the eventloop.

**Edit:** I just tried to use signals to cancel the awaitable in case of a Keyboard interrupt which would also work, but I'm not able to figure out a way to determine where the awaitable was stuck.

One problem I see with this commit is hard coding `ast.PyCF_ALLOW_TOP_LEVEL_AWAIT` in `python_input.PythonInput.get_compiler_flags`. If there are better approaches I would gladly take those. By the way this also solves #306 