### PR TITLE
Add PTPYTHON_CONFIG_HOME for explicitly setting a config dir.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,7 +149,12 @@ navigation mode.
 Configuration
 *************
 
-It is possible to create a ``$XDG_CONFIG_HOME/ptpython/config.py`` file to customize the configuration.
+It is possible to create a ``config.py`` file to customize configuration.
+ptpython will look in an appropriate platform-specific directory via `appdirs
+<https://pypi.org/project/appdirs/>`. See the ``appdirs`` documentation for the
+precise location for your platform. A ``PTPYTHON_CONFIG_HOME`` environment
+variable, if set, can also be used to explicitly override where configuration
+is looked for.
 
 Have a look at this example to see what is possible:
 `config.py <https://github.com/jonathanslenders/ptpython/blob/master/examples/ptpython_config/config.py>`_

--- a/ptpython/entry_points/run_ptpython.py
+++ b/ptpython/entry_points/run_ptpython.py
@@ -14,13 +14,16 @@ optional arguments:
   --history-file HISTORY_FILE
                         Location of history file.
   -V, --version         show program's version number and exit
-Other environment variables:
-PYTHONSTARTUP: file executed on interactive startup (no default)
+
+environment variables:
+  PTPYTHON_CONFIG_HOME: a configuration directory to use
+  PYTHONSTARTUP: file executed on interactive startup (no default)
 """
 import argparse
 import os
 import pathlib
 import sys
+from textwrap import dedent
 from typing import Tuple
 
 try:
@@ -40,8 +43,15 @@ __all__ = ["create_parser", "get_config_and_history_file", "run"]
 class _Parser(argparse.ArgumentParser):
     def print_help(self):
         super().print_help()
-        print("Other environment variables:")
-        print("PYTHONSTARTUP: file executed on interactive startup (no default)")
+        print(
+            dedent(
+                """
+                environment variables:
+                  PTPYTHON_CONFIG_HOME: a configuration directory to use
+                  PYTHONSTARTUP: file executed on interactive startup (no default)
+                """,
+            ).rstrip(),
+        )
 
 
 def create_parser() -> _Parser:
@@ -72,7 +82,10 @@ def get_config_and_history_file(namespace: argparse.Namespace) -> Tuple[str, str
     Check which config/history files to use, ensure that the directories for
     these files exist, and return the config and history path.
     """
-    config_dir = appdirs.user_config_dir("ptpython", "prompt_toolkit")
+    config_dir = os.environ.get(
+        "PTPYTHON_CONFIG_HOME",
+        appdirs.user_config_dir("ptpython", "prompt_toolkit"),
+    )
     data_dir = appdirs.user_data_dir("ptpython", "prompt_toolkit")
 
     # Create directories.

--- a/ptpython/entry_points/run_ptpython.py
+++ b/ptpython/entry_points/run_ptpython.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python
 """
 ptpython: Interactive Python shell.
-Usage:
-    ptpython [ --vi ]
-             [ --config-dir=<directory> ] [ --interactive=<filename> ]
-             [--] [ <arg>... ]
-    ptpython -h | --help
 
-Options:
-    --vi                         : Use Vi keybindings instead of Emacs bindings.
-    --config-dir=<directory>     : Pass config directory. By default '$XDG_CONFIG_HOME/ptpython'.
-    -i, --interactive=<filename> : Start interactive shell after executing this file.
+positional arguments:
+  args                  Script and arguments
 
+optional arguments:
+  -h, --help            show this help message and exit
+  --vi                  Enable Vi key bindings
+  -i, --interactive     Start interactive shell after executing this file.
+  --config-file CONFIG_FILE
+                        Location of configuration file.
+  --history-file HISTORY_FILE
+                        Location of history file.
+  -V, --version         show program's version number and exit
 Other environment variables:
 PYTHONSTARTUP: file executed on interactive startup (no default)
 """


### PR DESCRIPTION
In particular allows macOS users who desire to follow the Linux convention of putting config in ~/.config instead of the macOS one (in ~/Library/ApplicationSupport) to do so via setting e.g. `PTPYTHON_CONFIG_HOME=$XDG_CONFIG_HOME/.config`.

Closes: #346