### PR TITLE
Fix dictionary completion on Pandas objects.

### DIFF
--- a/ptpython/completer.py
+++ b/ptpython/completer.py
@@ -370,7 +370,9 @@ class DictionaryCompleter(Completer):
 
             if isinstance(result, (list, tuple, dict)):
                 yield Completion("[", 0)
-            elif result:
+            elif result is not None:
+                # Note: Don't call `if result` here. That can fail for types
+                #       that have custom truthness checks.
                 yield Completion(".", 0)
 
     def _get_item_lookup_completions(


### PR DESCRIPTION
This should fix the following error:

```python
  File ".../ptpython/completer.py", line 373, in _get_expression_completions
    elif result:
  File ".../pandas/core/generic.py", line 1330, in __nonzero__
    f"The truth value of a {type(self).__name__} is ambiguous. "