### PR TITLE
Added option for using pager to display big outputs.

### DIFF
--- a/examples/asyncio-python-embed.py
+++ b/examples/asyncio-python-embed.py
@@ -38,9 +38,7 @@ async def interactive_shell():
         'You should be able to read and update the "counter[0]" variable from this shell.'
     )
     try:
-        await embed(
-            globals=globals(), return_asyncio_coroutine=True, patch_stdout=True
-        )
+        await embed(globals=globals(), return_asyncio_coroutine=True, patch_stdout=True)
     except EOFError:
         # Stop the loop when quitting the repl. (Ctrl-D press.)
         loop.stop()

--- a/ptpython/entry_points/run_ptpython.py
+++ b/ptpython/entry_points/run_ptpython.py
@@ -95,7 +95,8 @@ def get_config_and_history_file(namespace: argparse.Namespace) -> Tuple[str, str
     these files exist, and return the config and history path.
     """
     config_dir = os.environ.get(
-        "PTPYTHON_CONFIG_HOME", appdirs.user_config_dir("ptpython", "prompt_toolkit"),
+        "PTPYTHON_CONFIG_HOME",
+        appdirs.user_config_dir("ptpython", "prompt_toolkit"),
     )
     data_dir = appdirs.user_data_dir("ptpython", "prompt_toolkit")
 

--- a/ptpython/python_input.py
+++ b/ptpython/python_input.py
@@ -261,6 +261,10 @@ class PythonInput:
         self.highlight_matching_parenthesis: bool = False
         self.show_sidebar: bool = False  # Currently show the sidebar.
 
+        # Pager.
+        self.enable_output_formatting: bool = False
+        self.use_pager_for_big_outputs: bool = False
+
         # When the sidebar is visible, also show the help text.
         self.show_sidebar_help: bool = True
 
@@ -734,6 +738,17 @@ class PythonInput:
                         title="Highlight parenthesis",
                         description="Highlight matching parenthesis, when the cursor is on or right after one.",
                         field_name="highlight_matching_parenthesis",
+                    ),
+                    simple_option(
+                        title="Reformat output (black)",
+                        description="Reformat outputs using Black, if possible (experimental).",
+                        field_name="enable_output_formatting",
+                    ),
+                    simple_option(
+                        title="Pager for big outputs",
+                        description="Use a pager for displaying bigger outputs if "
+                        "they don't fit on the screen (experimental).",
+                        field_name="use_pager_for_big_outputs",
                     ),
                 ],
             ),

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ setup(
         "jedi>=0.16.0",
         "prompt_toolkit>=3.0.0,<3.1.0",
         "pygments",
+        "pypager",
+        "black",
     ],
     python_requires=">=3.6",
     classifiers=[


### PR DESCRIPTION
Not 100% sure yet whether this is useful. The ``repr()`` of big strings are still one line. We probably have to hard-wrap them or not use the ``repr()``.