### PR TITLE
Update repl.py 

### DIFF
--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -553,7 +553,7 @@ def enable_deprecation_warnings() -> None:
     warnings.filterwarnings("default", category=DeprecationWarning, module="__main__")
 
 
-def run_config(repl: PythonInput, config_file: str = "~/.ptpython/config.py") -> None:
+def run_config(repl: PythonInput, config_file: str = "~/.config/ptpython/config.py") -> None:
     """
     Execute REPL config file.
 


### PR DESCRIPTION
use   _~/.config/ptpython/config.py_     instead of     _~/.ptpython/config.py_
Otherwise, the tool pudb will search  _~/.ptpython/config.py_  for config of ptpython and show that 

> Impossible to read  _~/.ptpython/config.py_