### PR TITLE
Several fixes to the completion code.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,8 @@ setup(
         "appdirs",
         "importlib_metadata;python_version<'3.8'",
         "jedi>=0.16.0",
-        # Use prompt_toolkit 3.0.12, because of dont_extend_width bugfix when
-        # signature and completion dropdown are displayed together.
-        "prompt_toolkit>=3.0.12,<3.1.0",
+        # Use prompt_toolkit 3.0.16, because of the `DeduplicateCompleter`.
+        "prompt_toolkit>=3.0.16,<3.1.0",
         "pygments",
         "black",
     ],


### PR DESCRIPTION
- Give dictionary completions priority over path completions.
- Always call non-fuzzy completer after fuzzy completer to prevent that some
  completions were missed out if the fuzzy completer doesn't find them.