### PR TITLE
Fix incorrect __main__ on script execution (#444)

### DIFF
--- a/ptpython/entry_points/run_ptipython.py
+++ b/ptpython/entry_points/run_ptipython.py
@@ -31,7 +31,7 @@ def run(user_ns=None):
         path = a.args[0]
         with open(path, "rb") as f:
             code = compile(f.read(), path, "exec")
-            exec(code, {})
+            exec(code, {'__name__': '__main__', '__file__': path})
     else:
         enable_deprecation_warnings()
 

--- a/ptpython/entry_points/run_ptpython.py
+++ b/ptpython/entry_points/run_ptpython.py
@@ -179,9 +179,11 @@ def run() -> None:
         path = a.args[0]
         with open(path, "rb") as f:
             code = compile(f.read(), path, "exec")
-            # NOTE: We have to pass an empty dictionary as namespace. Omitting
-            #       this argument causes imports to not be found. See issue #326.
-            exec(code, {})
+            # NOTE: We have to pass a dict as namespace. Omitting this argument
+            #       causes imports to not be found. See issue #326.
+            #       However, an empty dict sets __name__ to 'builtins', which
+            #       breaks `if __name__ == '__main__'` checks. See issue #444.
+            exec(code, {'__name__': '__main__', '__file__': path})
 
     # Run interactive shell.
     else:


### PR DESCRIPTION
Fixes #444.

This doesn't fix the "piped in from stdin" case, however. It's *unlikely* that it'll come up, but it's a nice thing to have.

```sh
; echo "exec('print(__file__, __name__)')" | python
<stdin> __main__
; echo "exec('print(__file__, __name__)')" | ptpython
Warning: Input is not a terminal (fd=0).
>>> exec('print(__file__, __name__)')
<snip>/.venv/bin/ptpython __main__
>>>
```