### PR TITLE
Fixed config example

### DIFF
--- a/examples/ptpython_config/config.py
+++ b/examples/ptpython_config/config.py
@@ -157,7 +157,7 @@ def configure(repl):
     @repl.add_key_binding("j", "j", filter=ViInsertMode())
     def _(event):
         " Map 'jj' to Escape. "
-        event.cli.key_processor.feed(KeyPress("escape"))
+        event.cli.key_processor.feed(KeyPress(Keys("escape")))
     """
 
     # Custom key binding for some simple autocorrection while typing.


### PR DESCRIPTION
Needed to pass Keys("escape") rather than the string literal.