### PR TITLE
Support using ptpython as a widget in another prompt_toolkit application.

### DIFF
--- a/ptpython/layout.py
+++ b/ptpython/layout.py
@@ -646,7 +646,7 @@ class PtPythonLayout:
         sidebar = python_sidebar(python_input)
         self.exit_confirmation = create_exit_confirmation(python_input)
 
-        root_container = HSplit(
+        self.root_container = HSplit(
             [
                 VSplit(
                     [
@@ -759,5 +759,5 @@ class PtPythonLayout:
             ]
         )
 
-        self.layout = Layout(root_container)
+        self.layout = Layout(self.root_container)
         self.sidebar = sidebar


### PR DESCRIPTION
Hello! This pull request fixes #450. It allows another fullscreen prompt_toolkit application to create it's own ptpython based repl embedded in a window. 

I haven't added any documentation changes yet but can write a guide and example of how this can be done. Would y'all be open to this change? Please let me know what tests I should try. Ptpython runs normally as far as I can tell with these changes.

A working example of using it can be found here: https://pigweed.googlesource.com/pigweed/pigweed/+/refs/heads/sandbox/pwconsole/pw_console/py/pw_console/pw_ptpython_repl.py

If you'd like to try it out run the following:
```sh
git clone https://pigweed.googlesource.com/pigweed/pigweed -b sandbox/pwconsole
cd pigweed
. ./bootstrap.sh
pw-console --loglevel debug --test-mode
```
If you are on windows substitute `. ./bootstrap.sh` for `bootstrap.bat`. 

The UI is still a work in progress. Shift-Tab will rotate focus between the panes.

`bootstrap.sh` will download ~5gb of tooling and setup a venv in the `.environment` folder. After testing feel free to delete it :-)
