### PR TITLE
Enable use of await in assignment expressions

### DIFF
--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -271,9 +271,14 @@ class PythonRepl(PythonInput):
                 self._store_eval_result(result)
                 return result
 
-            # If not a valid `eval` expression, run using `exec` instead.
+            # If not a valid `eval` expression, compile as `exec` expression
+            # but still run with eval to get an awaitable in case of a
+            # awaitable expression.
             code = self._compile_with_flags(line, "exec")
-            exec(code, self.get_globals(), self.get_locals())
+            result = eval(code, self.get_globals(), self.get_locals())
+
+            if _has_coroutine_flag(code):
+                result = await result
 
         return None
 


### PR DESCRIPTION
This tries to fix #447 and some other bugs concerning expressions, like
for instance `for` loops. Which cannot contain awaitables otherwise.

This is a bit dirty because it compiles code with `exec` while using `eval` to execute it.
To be honest I didn't read all the python docs but how you compile code and how you execute does not really matter (at least in my python implementation).
However I don't think that this is standardized.
But `exec` won't return something that we can await, however `eval` will do.

While this might be of concern I used this fix the last year and it never broke on me. I switched back when ptpython implemented asyncio stuff a bit cleaner than I did. Thanks for that btw.

Still this needs to be fixed because not being able to write `u = await a()` is quite annoying, even more annoying is not being able to use await inside of for loops and stuff.