### PR TITLE
Add '+dev' to version string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(os.path.dirname(__file__), "README.rst")) as f:
 setup(
     name="ptpython",
     author="Jonathan Slenders",
-    version="3.0.17",
+    version="3.0.17+dev",
     url="https://github.com/prompt-toolkit/ptpython",
     description="Python REPL build on top of prompt_toolkit",
     long_description=long_description,


### PR DESCRIPTION
This will let pip dependecies consider the version in git to be greater
than the same version in pypi. Note when making a new pypi release this
should be removed.

Fixes #461 