### PR TITLE
Don't crash when trying to complete broken mappings.

### DIFF
--- a/ptpython/completer.py
+++ b/ptpython/completer.py
@@ -505,6 +505,10 @@ class DictionaryCompleter(Completer):
                                 display=f"[{k_repr}]",
                                 display_meta=abbr_meta(self._do_repr(result[k])),
                             )
+                        except KeyError:
+                            # `result[k]` lookup failed. Trying to complete
+                            # broken object.
+                            pass
                         except ReprFailedError:
                             pass
 
@@ -521,6 +525,10 @@ class DictionaryCompleter(Completer):
                                     display=f"[{k_repr}]",
                                     display_meta=abbr_meta(self._do_repr(result[k])),
                                 )
+                            except KeyError:
+                                # `result[k]` lookup failed. Trying to complete
+                                # broken object.
+                                pass
                             except ReprFailedError:
                                 pass
 

--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -135,6 +135,12 @@ class PythonRepl(PythonInput):
                     text = self.read()
                 except EOFError:
                     return
+                except BaseException as e:
+                    # Something went wrong while reading input.
+                    # (E.g., a bug in the completer that propagates. Don't
+                    # crash the REPL.)
+                    traceback.print_exc()
+                    continue
 
                 # Run it; display the result (or errors if applicable).
                 self.run_and_show_expression(text)
@@ -192,6 +198,12 @@ class PythonRepl(PythonInput):
                         text = await loop.run_in_executor(None, self.read)
                     except EOFError:
                         return
+                    except BaseException:
+                        # Something went wrong while reading input.
+                        # (E.g., a bug in the completer that propagates. Don't
+                        # crash the REPL.)
+                        traceback.print_exc()
+                        continue
 
                     # Eval.
                     await self.run_and_show_expression_async(text)


### PR DESCRIPTION
Show the traceback when something goes wrong while reading input in the REPL
due to completer bugs or other bugs. Don't crash the REPL.