### PR TITLE
Raising Import Error if Mode not in black - older versions don't have…

### DIFF
--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -345,6 +345,9 @@ class PythonRepl(PythonInput):
                 # not used.
                 try:
                     import black
+
+                    if not hasattr(black, "Mode"):
+                        raise ImportError
                 except ImportError:
                     pass  #   no Black package in your installation
                 else:


### PR DESCRIPTION
Some black versions are missing Mode, the change should raise an ImportError when it's missing.