### PR TITLE
fix(run_ptpython): importlib.metadata on different python version

### DIFF
--- a/ptpython/entry_points/run_ptpython.py
+++ b/ptpython/entry_points/run_ptpython.py
@@ -35,7 +35,10 @@ from prompt_toolkit.shortcuts import print_formatted_text
 from ptpython.repl import embed, enable_deprecation_warnings, run_config
 
 try:
-    from importlib import metadata
+    if sys.version_info >= (3, 8):
+        import importlib.metadata as metadata
+    else:
+        import importlib_metadata as metadata
 except ImportError:
     import importlib_metadata as metadata  # type: ignore
 


### PR DESCRIPTION
this pr is based on https://github.com/pypa/build/pull/213/files

i only modify `try` section so if any error happen it will default to `except` section