### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/concurrency-challenges.rst
+++ b/docs/concurrency-challenges.rst
@@ -67,7 +67,7 @@ When a normal blocking embed is used:
 When an awaitable embed is used, for embedding in a coroutine, but having the
 event loop continue:
     * We run the input method from the blocking embed in an asyncio executor
-      and do an `await loop.run_in_excecutor(...)`.
+      and do an `await loop.run_in_executor(...)`.
     * The "eval" happens again in the main thread.
     * "print" is also similar, except that the pager code (if used) runs in an
       executor too.

--- a/examples/ptpython_config/config.py
+++ b/examples/ptpython_config/config.py
@@ -49,7 +49,7 @@ def configure(repl):
     # Swap light/dark colors on or off
     repl.swap_light_and_dark = False
 
-    # Highlight matching parethesis.
+    # Highlight matching parentheses.
     repl.highlight_matching_parenthesis = True
 
     # Line wrapping. (Instead of horizontal scrolling.)

--- a/ptpython/completer.py
+++ b/ptpython/completer.py
@@ -586,7 +586,7 @@ class DictionaryCompleter(Completer):
 
 class HidePrivateCompleter(Completer):
     """
-    Wrapper around completer that hides private fields, deponding on whether or
+    Wrapper around completer that hides private fields, depending on whether or
     not public fields are shown.
 
     (The reason this is implemented as a `Completer` wrapper is because this

--- a/ptpython/history_browser.py
+++ b/ptpython/history_browser.py
@@ -563,7 +563,7 @@ class PythonHistory:
         Create an `Application` for the history screen.
         This has to be run as a sub application of `python_input`.
 
-        When this application runs and returns, it retuns the selected lines.
+        When this application runs and returns, it returns the selected lines.
         """
         self.python_input = python_input
 

--- a/ptpython/key_bindings.py
+++ b/ptpython/key_bindings.py
@@ -148,7 +148,7 @@ def load_python_bindings(python_input):
         Behaviour of the Enter key.
 
         Auto indent after newline/Enter.
-        (When not in Vi navigaton mode, and when multiline is enabled.)
+        (When not in Vi navigation mode, and when multiline is enabled.)
         """
         b = event.current_buffer
         empty_lines_required = python_input.accept_input_on_enter or 10000

--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -401,7 +401,7 @@ class PythonRepl(PythonInput):
 
     def show_result(self, result: object) -> None:
         """
-        Show __repr__ for an `eval` result and print to ouptut.
+        Show __repr__ for an `eval` result and print to output.
         """
         formatted_text_output = self._format_result_output(result)
 


### PR DESCRIPTION
There are small typos in:
- docs/concurrency-challenges.rst
- examples/ptpython_config/config.py
- ptpython/completer.py
- ptpython/history_browser.py
- ptpython/key_bindings.py
- ptpython/repl.py

Fixes:
- Should read `returns` rather than `retuns`.
- Should read `parentheses` rather than `parethesis`.
- Should read `output` rather than `ouptut`.
- Should read `navigation` rather than `navigaton`.
- Should read `executor` rather than `excecutor`.
- Should read `depending` rather than `deponding`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md