### PR TITLE
Add completes for shells by shtab

### DIFF
--- a/ptpython/_shtab.py
+++ b/ptpython/_shtab.py
@@ -1,0 +1,8 @@
+FILE = None
+DIRECTORY = DIR = None
+
+
+def add_argument_to(parser, *args, **kwargs):
+    from argparse import Action
+    Action.complete = None
+    return parser

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     packages=find_packages("."),
     package_data={"ptpython": ["py.typed"]},
     install_requires=[
+        "shtab",
         "appdirs",
         "importlib_metadata;python_version<'3.8'",
         "jedi>=0.16.0",
@@ -50,5 +51,6 @@ setup(
     extras_require={
         "ptipython": ["ipython"],  # For ptipython, we need to have IPython
         "all": ["black"],  # Black not always possible on PyPy
+        "completion": ["shtab"],
     },
 )


### PR DESCRIPTION
```
ptpython --print-completion bash | sudo tee /usr/share/bash-completion/completions/ptpython
ptpython --print-completion zsh | sed 's/compdef ptpython/compdef -P pt(i|)python[0-9.]#/' | sudo tee /usr/share/zsh/site-functions/_ptpython  # wait <https://github.com/iterative/shtab/issues/87>
ptpython --print-completion tcsh | sudo tee /etc/profile.d/ptpython.completion.csh
```

Same as <https://github.com/inducer/pudb/pull/546>. And fix #508

```zsh
❯ ptpython --print-completion zsh | sed 's/compdef ptpython/compdef -P pt(i|)python[0-9.]#/' | xsel -ib
#compdef -P pt(i|)python[0-9.]#

# AUTOMATCALLY GENERATED by `shtab`


_shtab_ptpython_commands() {
  local _commands=(
    
  )
  _describe 'ptpython commands' _commands
}

_shtab_ptpython_options=(
  "(- : *)"{-h,--help}"[show this help message and exit]"
  "(- : *)--print-completion[print shell completion script]:print_completion:(bash zsh tcsh)"
  "--vi[Enable Vi key bindings]"
  {-i,--interactive}"[Start interactive shell after executing this file.]"
  "--light-bg[Run on a light background (use dark colors for text).]"
  "--dark-bg[Run on a dark background (use light colors for text).]"
  "--config-file[Location of configuration file.]:config_file:_files -g *.py"
  "--history-file[Location of history file.]:history_file:_files"
  "(- : *)"{-V,--version}"[show program\'s version number and exit]"
  "(-)*:Script and arguments:_script_args"
)


_shtab_ptpython() {
  local context state line curcontext="$curcontext"

  local one_or_more='(-)*'
  local reminder='(*)'
  if ((${_shtab_you_get_options[(I)${(q)one_or_more}*]} + ${_shtab_you_get_options[(I)${(q)reminder}*]} == 0)); then  # noqa: E501
    _shtab_ptpython_options+=(': :_shtab_ptpython_commands' '*::: :->ptpython')
  fi
  _arguments -C $_shtab_ptpython_options

  case $state in
    ptpython)
      words=($line[1] "${words[@]}")
      (( CURRENT += 1 ))
      curcontext="${curcontext%:*:*}:_shtab_ptpython-$line[1]:"
      case $line[1] in
        
      esac
  esac
}

# Custom Preamble
_script_args() {
  _arguments -S -s '(-)1:script_args:_files -g *.py' '*: :_files'
}

# End Custom Preamble


typeset -A opt_args
_shtab_ptpython "$@"
```
