### PR TITLE
docs: Add windows terminal profile configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -240,6 +240,22 @@ Windows. Some things might not work, but it is usable:
 
 .. image :: https://github.com/jonathanslenders/ptpython/raw/master/docs/images/windows.png
 
+Windows terminal integration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you are using the `Windows Terminal <https://aka.ms/terminal>`_ and want to 
+integrate ``ptpython`` as a profile, go to *Settings -> Open JSON file* and add the
+following profile under *profiles.list*:
+
+.. code-block:: JSON
+
+    {
+        "commandline": "%SystemRoot%\\System32\\cmd.exe /k ptpython",
+        "guid": "{f91d49a3-741b-409c-8a15-c4360649121f}",
+        "hidden": false,
+        "icon": "https://upload.wikimedia.org/wikipedia/commons/e/e6/Python_Windows_interpreter_icon_2006%E2%80%932016_Tiny.png",
+        "name": "ptpython@cmd"
+    }
 
 FAQ
 ***


### PR DESCRIPTION
## Description

This PR adds a short description to the README of how to add a profile to the new Windows Terminal.

## Benefit Hypothesis

For many Python users `ptpython` is the go-to REPL from the command line. In addition, the new _Windows Terminal_ is very flexible and allows different profiles (aka consoles) to be added. Having a dedicated profile, will allow one-click creation of `ptpython` consoles and therefore avoid unnecessary micro-waste in day-to-day work. 