### PR TITLE
Don't print exception twice in exception handler.

### DIFF
--- a/ptpython/completer.py
+++ b/ptpython/completer.py
@@ -189,7 +189,6 @@ class PythonCompleter(Completer):
         ):
             # If we are inside a string, Don't do Jedi completion.
             if not self._path_completer_grammar.match(document.text_before_cursor):
-
                 # Do Jedi Python completions.
                 yield from self._jedi_completer.get_completions(
                     document, complete_event
@@ -399,7 +398,6 @@ class DictionaryCompleter(Completer):
     def get_completions(
         self, document: Document, complete_event: CompleteEvent
     ) -> Iterable[Completion]:
-
         # First, find all for-loops, and assign the first item of the
         # collections they're iterating to the iterator variable, so that we
         # can provide code completion on the iterators.
@@ -454,7 +452,6 @@ class DictionaryCompleter(Completer):
         result = self.eval_expression(document, temp_locals)
 
         if result is not None:
-
             if isinstance(
                 result,
                 (list, tuple, dict, collections_abc.Mapping, collections_abc.Sequence),
@@ -478,6 +475,7 @@ class DictionaryCompleter(Completer):
 
         def meta_repr(value: object) -> Callable[[], str]:
             "Abbreviate meta text, make sure it fits on one line."
+
             # We return a function, so that it gets computed when it's needed.
             # When there are many completions, that improves the performance
             # quite a bit (for the multi-column completion menu, we only need
@@ -617,7 +615,6 @@ class HidePrivateCompleter(Completer):
     def get_completions(
         self, document: Document, complete_event: CompleteEvent
     ) -> Iterable[Completion]:
-
         completions = list(self.completer.get_completions(document, complete_event))
         complete_private_attributes = self.complete_private_attributes()
         hide_private = False

--- a/ptpython/python_input.py
+++ b/ptpython/python_input.py
@@ -213,7 +213,6 @@ class PythonInput:
         _extra_toolbars=None,
         _input_buffer_height=None,
     ) -> None:
-
         self.get_globals: _GetNamespace = get_globals or (lambda: {})
         self.get_locals: _GetNamespace = get_locals or self.get_globals
 
@@ -1043,6 +1042,7 @@ class PythonInput:
 
         This can raise EOFError, when Control-D is pressed.
         """
+
         # Capture the current input_mode in order to restore it after reset,
         # for ViState.reset() sets it to InputMode.INSERT unconditionally and
         # doesn't accept any arguments.

--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -96,7 +96,8 @@ class PythonRepl(PythonInput):
             # Eval.
             try:
                 result = self.eval(expression)
-            except KeyboardInterrupt:  # KeyboardInterrupt doesn't inherit from Exception.
+            except KeyboardInterrupt:
+                # KeyboardInterrupt doesn't inherit from Exception.
                 raise
             except SystemExit:
                 raise

--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -573,8 +573,6 @@ class PythonRepl(PythonInput):
             include_default_pygments_style=False,
             output=output,
         )
-
-        output.write("%s\n" % e)
         output.flush()
 
     def _handle_keyboard_interrupt(self, e: KeyboardInterrupt) -> None:


### PR DESCRIPTION
The exception formatting itself already prints the exception message. Printing the exception again leads to lots of duplicated output if the exception contains a long multiline message.