### PR TITLE
Add license metadata to setup.py

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015, Jonathan Slenders
+Copyright (c) 2015-2023, Jonathan Slenders
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     ],
     python_requires=">=3.7",
     classifiers=[
+        "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Due to the lack of metadata in the package, license checkers like `pylic` are reporting that this package is unsafe.
This PR aims to fix that.

- Add BSD License classifier to setup.py
- Update copyright dates
