### PR TITLE
Fix IPython DeprecationWarning

### DIFF
--- a/ptpython/ipython.py
+++ b/ptpython/ipython.py
@@ -14,7 +14,7 @@ from typing import Iterable
 from warnings import warn
 
 from IPython import utils as ipy_utils
-from IPython.core.inputsplitter import IPythonInputSplitter
+from IPython.core.inputtransformer2 import TransformerManager
 from IPython.terminal.embed import InteractiveShellEmbed as _InteractiveShellEmbed
 from IPython.terminal.ipapp import load_default_config
 from prompt_toolkit.completion import (
@@ -65,7 +65,7 @@ class IPythonPrompt(PromptStyle):
 class IPythonValidator(PythonValidator):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.isp = IPythonInputSplitter()
+        self.isp = TransformerManager()
 
     def validate(self, document: Document) -> None:
         document = Document(text=self.isp.transform_cell(document.text))


### PR DESCRIPTION
ptipython raises the following error since IPython 7:
> IPython.core.inputsplitter is deprecated since IPython 7 in favor of `IPython.core.inputtransformer2`