### PR TITLE
[RFC] `run_config()`: skip interrupt if `config_file` not found

### DIFF
--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -631,13 +631,16 @@ def enable_deprecation_warnings() -> None:
 
 
 def run_config(
-    repl: PythonInput, config_file: str = "~/.config/ptpython/config.py"
+    repl: PythonInput,
+    config_file: str = "~/.config/ptpython/config.py",
+    interrupt_if_not_found: bool = False,
 ) -> None:
     """
     Execute REPL config file.
 
     :param repl: `PythonInput` instance.
     :param config_file: Path of the configuration file.
+    :param interrupt_if_not_found: Whether to interrupt if config_file does not exist.
     """
     # Expand tildes.
     config_file = os.path.expanduser(config_file)
@@ -646,7 +649,7 @@ def run_config(
         input("\nPress ENTER to continue...")
 
     # Check whether this file exists.
-    if not os.path.exists(config_file):
+    if not os.path.exists(config_file) and interrupt_if_not_found:
         print("Impossible to read %r" % config_file)
         enter_to_continue()
         return


### PR DESCRIPTION
Resolves #549

## Problem

Downstream packages (e.g. [django-extension](https://github.com/django-extensions/django-extensions8)'s [`shell_plus`](https://github.com/django-extensions/django-extensions/blob/dd794f1b239d657f62d40f2c3178200978328ed7/django_extensions/management/commands/shell_plus.py#L434-L438)) use [`ptpython.repl.run_config()`](https://github.com/prompt-toolkit/ptpython/blob/3.0.23/ptpython/repl.py#L633-L652) to use the system's optional ptpython config files. The result is users can be surprised by `run_config()` interrupting the terminal for a config file they didn't explicitly request: ptpython had the default.

## Current behavior
`run_config()` specifies a default configuration file, which may or may not exist on systems.
[`ptpython.repl.embed()`](https://github.com/prompt-toolkit/ptpython/blob/44f0c6e57d616d41de458daccbf36e8d8eb5fb3d/ptpython/repl.py#L672-L743) runs flawlessly if `run_config()` returns an empty value.

## What this change does

Adds `interrupt_if_not_found` with default of False.

## Other options

- Do nothing, accept current behavior
- `interrupt_if_not_found` default to `True`

   This means downstream packages will need to check `ptpython` version and expliclitly opt in via `interrupt_if_not_found=False`.
- #551: Only interrupt if explicit `config_file` passed
- Remove default `config_file` param.

   _Return `None` if no `config_file` passed._