### PR TITLE
[RFC] `run_config()`: skip interrupt unless explicitly passed `config_file`

### DIFF
--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -630,23 +630,28 @@ def enable_deprecation_warnings() -> None:
     warnings.filterwarnings("default", category=DeprecationWarning, module="__main__")
 
 
-def run_config(
-    repl: PythonInput, config_file: str = "~/.config/ptpython/config.py"
-) -> None:
+DEFAULT_CONFIG_FILE = "~/.config/ptpython/config.py"
+
+
+def run_config(repl: PythonInput, config_file: str | None = None) -> None:
     """
     Execute REPL config file.
 
     :param repl: `PythonInput` instance.
     :param config_file: Path of the configuration file.
     """
+    explicit_config_file = config_file is not None
+
     # Expand tildes.
-    config_file = os.path.expanduser(config_file)
+    config_file = os.path.expanduser(
+        config_file if config_file is not None else DEFAULT_CONFIG_FILE
+    )
 
     def enter_to_continue() -> None:
         input("\nPress ENTER to continue...")
 
     # Check whether this file exists.
-    if not os.path.exists(config_file):
+    if not os.path.exists(config_file) and explicit_config_file:
         print("Impossible to read %r" % config_file)
         enter_to_continue()
         return


### PR DESCRIPTION
Resolves #549

## Problem

Downstream packages (e.g. [django-extension](https://github.com/django-extensions/django-extensions8)'s [`shell_plus`](https://github.com/django-extensions/django-extensions/blob/dd794f1b239d657f62d40f2c3178200978328ed7/django_extensions/management/commands/shell_plus.py#L434-L438)) use [`ptpython.repl.run_config()`](https://github.com/prompt-toolkit/ptpython/blob/3.0.23/ptpython/repl.py#L633-L652) to use the system's optional ptpython config files. The result is users can be surprised by `run_config()` interrupting the terminal for a config file they didn't explicitly request: ptpython had the default.

## Current behavior
`run_config()` specifies a default configuration file, which may or may not exist on systems.
[`ptpython.repl.embed()`](https://github.com/prompt-toolkit/ptpython/blob/44f0c6e57d616d41de458daccbf36e8d8eb5fb3d/ptpython/repl.py#L672-L743) runs flawlessly if `run_config()` returns an empty value.

## What this change does

1. Extracts default `config_file` into constant: `DEFAULT_CONFIG_FILE`
2. Checks for `config_file` being nullish

   - If yes (nullish), set `explicit_config_file` to `True`, then:
   
      - Set the empty `config_file` to `DEFAULT_CONFIG_FILE`.
      
        Preserving default behavior
     - If no (explicit value passed), set `explicit_config_file` to `False`
3. Check for `explicit_config_file` in condition that runs:

    ```python
    print("Impossible to read %r" % config_file)
    enter_to_continue()
    return
    ```

## Other options

- Do nothing, accept current behavior
- #550: New param `interrupt_if_not_found` (bool)
- Remove default `config_file` param.

   _Return `None` if no `config_file` passed._