### PR TITLE
Add cursor_shape_config example

### DIFF
--- a/examples/ptpython_config/config.py
+++ b/examples/ptpython_config/config.py
@@ -70,6 +70,9 @@ def configure(repl):
     # Vi mode.
     repl.vi_mode = False
 
+    # Enable the modal cursor (when using Vi mode). Other options are 'Block', 'Underline',  'Beam',  'Blink under', 'Blink block', and 'Blink beam'
+    repl.cursor_shape_config = 'Modal (vi)'
+
     # Paste mode. (When True, don't insert whitespace after new line.)
     repl.paste_mode = False
 


### PR DESCRIPTION
Describe setting the cursor shape to modal for Vi mode. List other possible options for the setting.

Thanks to [mohamed-180](https://github.com/prompt-toolkit/ptpython/issues/548) for the setting info.