### PR TITLE
Refactor output printer so that it can render big outputs without memory issues.

### DIFF
--- a/examples/asyncio-python-embed.py
+++ b/examples/asyncio-python-embed.py
@@ -19,7 +19,7 @@ loop = asyncio.get_event_loop()
 counter = [0]
 
 
-async def print_counter():
+async def print_counter() -> None:
     """
     Coroutine that prints counters and saves it in a global variable.
     """
@@ -29,7 +29,7 @@ async def print_counter():
         await asyncio.sleep(3)
 
 
-async def interactive_shell():
+async def interactive_shell() -> None:
     """
     Coroutine that starts a Python REPL from which we can access the global
     counter variable.
@@ -44,13 +44,10 @@ async def interactive_shell():
         loop.stop()
 
 
-def main():
-    asyncio.ensure_future(print_counter())
-    asyncio.ensure_future(interactive_shell())
-
-    loop.run_forever()
-    loop.close()
+async def main() -> None:
+    asyncio.create_task(print_counter())
+    await interactive_shell()
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/examples/asyncio-ssh-python-embed.py
+++ b/examples/asyncio-ssh-python-embed.py
@@ -32,31 +32,25 @@ class MySSHServer(asyncssh.SSHServer):
         return ReplSSHServerSession(self.get_namespace)
 
 
-def main(port=8222):
+async def main(port: int = 8222) -> None:
     """
     Example that starts the REPL through an SSH server.
     """
-    loop = asyncio.get_event_loop()
-
     # Namespace exposed in the REPL.
     environ = {"hello": "world"}
 
     # Start SSH server.
-    def create_server():
+    def create_server() -> MySSHServer:
         return MySSHServer(lambda: environ)
 
     print("Listening on :%i" % port)
     print('To connect, do "ssh localhost -p %i"' % port)
 
-    loop.run_until_complete(
-        asyncssh.create_server(
-            create_server, "", port, server_host_keys=["/etc/ssh/ssh_host_dsa_key"]
-        )
+    await asyncssh.create_server(
+        create_server, "", port, server_host_keys=["/etc/ssh/ssh_host_dsa_key"]
     )
-
-    # Run eventloop.
-    loop.run_forever()
+    await asyncio.Future()  # Wait forever.
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/examples/python-embed-with-custom-prompt.py
+++ b/examples/python-embed-with-custom-prompt.py
@@ -2,26 +2,26 @@
 """
 Example of embedding a Python REPL, and setting a custom prompt.
 """
-from prompt_toolkit.formatted_text import HTML
+from prompt_toolkit.formatted_text import HTML, AnyFormattedText
 
 from ptpython.prompt_style import PromptStyle
 from ptpython.repl import embed
 
 
-def configure(repl):
+def configure(repl) -> None:
     # Probably, the best is to add a new PromptStyle to `all_prompt_styles` and
     # activate it. This way, the other styles are still selectable from the
     # menu.
     class CustomPrompt(PromptStyle):
-        def in_prompt(self):
+        def in_prompt(self) -> AnyFormattedText:
             return HTML("<ansigreen>Input[%s]</ansigreen>: ") % (
                 repl.current_statement_index,
             )
 
-        def in2_prompt(self, width):
+        def in2_prompt(self, width: int) -> AnyFormattedText:
             return "...: ".rjust(width)
 
-        def out_prompt(self):
+        def out_prompt(self) -> AnyFormattedText:
             return HTML("<ansired>Result[%s]</ansired>: ") % (
                 repl.current_statement_index,
             )
@@ -30,7 +30,7 @@ def configure(repl):
     repl.prompt_style = "custom"
 
 
-def main():
+def main() -> None:
     embed(globals(), locals(), configure=configure)
 
 

--- a/examples/python-embed.py
+++ b/examples/python-embed.py
@@ -4,7 +4,7 @@
 from ptpython.repl import embed
 
 
-def main():
+def main() -> None:
     embed(globals(), locals(), vi_mode=False)
 
 

--- a/examples/ssh-and-telnet-embed.py
+++ b/examples/ssh-and-telnet-embed.py
@@ -11,13 +11,16 @@ import pathlib
 
 import asyncssh
 from prompt_toolkit import print_formatted_text
-from prompt_toolkit.contrib.ssh.server import PromptToolkitSSHServer
+from prompt_toolkit.contrib.ssh.server import (
+    PromptToolkitSSHServer,
+    PromptToolkitSSHSession,
+)
 from prompt_toolkit.contrib.telnet.server import TelnetServer
 
 from ptpython.repl import embed
 
 
-def ensure_key(filename="ssh_host_key"):
+def ensure_key(filename: str = "ssh_host_key") -> str:
     path = pathlib.Path(filename)
     if not path.exists():
         rsa_key = asyncssh.generate_private_key("ssh-rsa")
@@ -25,12 +28,12 @@ def ensure_key(filename="ssh_host_key"):
     return str(path)
 
 
-async def interact(connection=None):
+async def interact(connection: PromptToolkitSSHSession) -> None:
     global_dict = {**globals(), "print": print_formatted_text}
     await embed(return_asyncio_coroutine=True, globals=global_dict)
 
 
-async def main(ssh_port=8022, telnet_port=8023):
+async def main(ssh_port: int = 8022, telnet_port: int = 8023) -> None:
     ssh_server = PromptToolkitSSHServer(interact=interact)
     await asyncssh.create_server(
         lambda: ssh_server, "", ssh_port, server_host_keys=[ensure_key()]

--- a/ptpython/contrib/asyncssh_repl.py
+++ b/ptpython/contrib/asyncssh_repl.py
@@ -110,7 +110,7 @@ class ReplSSHServerSession(asyncssh.SSHServerSession[str]):
         """
         When data is received, send to inputstream of the CLI and repaint.
         """
-        self._input_pipe.send(data)
+        self._input_pipe.send(data)  # type: ignore
 
     def _print(
         self, *data: object, sep: str = " ", end: str = "\n", file: Any = None

--- a/ptpython/entry_points/run_ptpython.py
+++ b/ptpython/entry_points/run_ptpython.py
@@ -9,6 +9,7 @@ optional arguments:
   -h, --help            show this help message and exit
   --vi                  Enable Vi key bindings
   -i, --interactive     Start interactive shell after executing this file.
+  --asyncio             Run an asyncio event loop to support top-level "await".
   --light-bg            Run on a light background (use dark colors for text).
   --dark-bg             Run on a dark background (use light colors for text).
   --config-file CONFIG_FILE
@@ -24,6 +25,7 @@ environment variables:
 from __future__ import annotations
 
 import argparse
+import asyncio
 import os
 import pathlib
 import sys
@@ -67,6 +69,11 @@ def create_parser() -> _Parser:
         "--interactive",
         action="store_true",
         help="Start interactive shell after executing this file.",
+    )
+    parser.add_argument(
+        "--asyncio",
+        action="store_true",
+        help='Run an asyncio event loop to support top-level "await".',
     )
     parser.add_argument(
         "--light-bg",
@@ -206,7 +213,7 @@ def run() -> None:
 
         import __main__
 
-        embed(
+        embed_result = embed(  # type: ignore
             vi_mode=a.vi,
             history_filename=history_file,
             configure=configure,
@@ -214,7 +221,11 @@ def run() -> None:
             globals=__main__.__dict__,
             startup_paths=startup_paths,
             title="Python REPL (ptpython)",
+            return_asyncio_coroutine=a.asyncio,
         )
+
+        if a.asyncio:
+            asyncio.run(embed_result)
 
 
 if __name__ == "__main__":

--- a/ptpython/printer.py
+++ b/ptpython/printer.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+import sys
+import traceback
+from dataclasses import dataclass
+from enum import Enum
+from typing import Generator, Iterable
+
+from prompt_toolkit.formatted_text import (
+    HTML,
+    AnyFormattedText,
+    FormattedText,
+    OneStyleAndTextTuple,
+    StyleAndTextTuples,
+    fragment_list_width,
+    merge_formatted_text,
+    to_formatted_text,
+)
+from prompt_toolkit.formatted_text.utils import split_lines
+from prompt_toolkit.input import Input
+from prompt_toolkit.key_binding import KeyBindings, KeyPressEvent
+from prompt_toolkit.output import Output
+from prompt_toolkit.shortcuts import PromptSession, print_formatted_text
+from prompt_toolkit.styles import BaseStyle, StyleTransformation
+from prompt_toolkit.styles.pygments import pygments_token_to_classname
+from prompt_toolkit.utils import get_cwidth
+from pygments.lexers import PythonLexer, PythonTracebackLexer
+
+__all__ = ["OutputPrinter"]
+
+# Never reformat results larger than this:
+MAX_REFORMAT_SIZE = 1_000_000
+
+
+@dataclass
+class OutputPrinter:
+    """
+    Result printer.
+
+    Usage::
+
+        printer = OutputPrinter(...)
+        printer.display_result(...)
+        printer.display_exception(...)
+    """
+
+    output: Output
+    input: Input
+    style: BaseStyle
+    title: AnyFormattedText
+    style_transformation: StyleTransformation
+
+    def display_result(
+        self,
+        result: object,
+        *,
+        out_prompt: AnyFormattedText,
+        reformat: bool,
+        highlight: bool,
+        paginate: bool,
+    ) -> None:
+        """
+        Show __repr__ (or `__pt_repr__`) for an `eval` result and print to output.
+
+        :param reformat: Reformat result using 'black' before printing if the
+            result is parsable as Python code.
+        :param highlight: Syntax highlight the result.
+        :param paginate: Show paginator when the result does not fit on the
+            screen.
+        """
+        out_prompt = to_formatted_text(out_prompt)
+        out_prompt_width = fragment_list_width(out_prompt)
+
+        result = self._insert_out_prompt_and_split_lines(
+            self._format_result_output(
+                result,
+                reformat=reformat,
+                highlight=highlight,
+                line_length=self.output.get_size().columns - out_prompt_width,
+                paginate=paginate,
+            ),
+            out_prompt=out_prompt,
+        )
+        self._display_result(result, paginate=paginate)
+
+    def display_exception(
+        self, e: BaseException, *, highlight: bool, paginate: bool
+    ) -> None:
+        """
+        Render an exception.
+        """
+        result = self._insert_out_prompt_and_split_lines(
+            self._format_exception_output(e, highlight=highlight),
+            out_prompt="",
+        )
+        self._display_result(result, paginate=paginate)
+
+    def display_style_and_text_tuples(
+        self,
+        result: Iterable[OneStyleAndTextTuple],
+        *,
+        paginate: bool,
+    ) -> None:
+        self._display_result(
+            self._insert_out_prompt_and_split_lines(result, out_prompt=""),
+            paginate=paginate,
+        )
+
+    def _display_result(
+        self,
+        lines: Iterable[StyleAndTextTuples],
+        *,
+        paginate: bool,
+    ) -> None:
+        if paginate:
+            self._print_paginated_formatted_text(lines)
+        else:
+            for line in lines:
+                self._print_formatted_text(line)
+
+        self.output.flush()
+
+    def _print_formatted_text(self, line: StyleAndTextTuples, end: str = "\n") -> None:
+        print_formatted_text(
+            FormattedText(line),
+            style=self.style,
+            style_transformation=self.style_transformation,
+            include_default_pygments_style=False,
+            output=self.output,
+            end=end,
+        )
+
+    def _format_result_output(
+        self,
+        result: object,
+        *,
+        reformat: bool,
+        highlight: bool,
+        line_length: int,
+        paginate: bool,
+    ) -> Generator[OneStyleAndTextTuple, None, None]:
+        """
+        Format __repr__ for an `eval` result.
+
+        Note: this can raise `KeyboardInterrupt` if either calling `__repr__`,
+              `__pt_repr__` or formatting the output with "Black" takes to long
+              and the user presses Control-C.
+        """
+        # If __pt_repr__ is present, take this. This can return prompt_toolkit
+        # formatted text.
+        try:
+            if hasattr(result, "__pt_repr__"):
+                formatted_result_repr = to_formatted_text(
+                    getattr(result, "__pt_repr__")()
+                )
+                yield from formatted_result_repr
+                return
+        except KeyboardInterrupt:
+            raise  # Don't catch here.
+        except:
+            # For bad code, `__getattr__` can raise something that's not an
+            # `AttributeError`. This happens already when calling `hasattr()`.
+            pass
+
+        # Call `__repr__` of given object first, to turn it in a string.
+        try:
+            result_repr = repr(result)
+        except KeyboardInterrupt:
+            raise  # Don't catch here.
+        except BaseException as e:
+            # Calling repr failed.
+            self.display_exception(e, highlight=highlight, paginate=paginate)
+            return
+
+        # Determine whether it's valid Python code. If not,
+        # reformatting/highlighting won't be applied.
+        if len(result_repr) < MAX_REFORMAT_SIZE:
+            try:
+                compile(result_repr, "", "eval")
+            except SyntaxError:
+                valid_python = False
+            else:
+                valid_python = True
+        else:
+            valid_python = False
+
+        if valid_python and reformat:
+            # Inline import. Slightly speed up start-up time if black is
+            # not used.
+            try:
+                import black
+
+                if not hasattr(black, "Mode"):
+                    raise ImportError
+            except ImportError:
+                pass  # no Black package in your installation
+            else:
+                result_repr = black.format_str(
+                    result_repr,
+                    mode=black.Mode(line_length=line_length),
+                )
+
+        if valid_python and highlight:
+            yield from _lex_python_result(result_repr)
+        else:
+            yield ("", result_repr)
+
+    def _insert_out_prompt_and_split_lines(
+        self, result: Iterable[OneStyleAndTextTuple], out_prompt: AnyFormattedText
+    ) -> Iterable[StyleAndTextTuples]:
+        r"""
+        Split styled result in lines (based on the \n characters in the result)
+        an insert output prompt on whitespace in front of each line. (This does
+        not yet do the soft wrapping.)
+
+        Yield lines as a result.
+        """
+        out_prompt = to_formatted_text(out_prompt)
+        out_prompt_width = fragment_list_width(out_prompt)
+        prefix = ("", " " * out_prompt_width)
+
+        for i, line in enumerate(split_lines(result)):
+            if i == 0:
+                line = [*out_prompt, *line]
+            else:
+                line = [prefix, *line]
+            yield line
+
+    def _apply_soft_wrapping(
+        self, lines: Iterable[StyleAndTextTuples]
+    ) -> Iterable[StyleAndTextTuples]:
+        """
+        Apply soft wrapping to the given lines. Wrap according to the terminal
+        width. Insert whitespace in front of each wrapped line to align it with
+        the output prompt.
+        """
+        line_length = self.output.get_size().columns
+
+        # Iterate over hard wrapped lines.
+        for lineno, line in enumerate(lines):
+            columns_in_buffer = 0
+            current_line: list[OneStyleAndTextTuple] = []
+
+            for style, text, *_ in line:
+                for c in text:
+                    width = get_cwidth(c)
+
+                    # (Soft) wrap line if it doesn't fit.
+                    if columns_in_buffer + width > line_length:
+                        yield current_line
+                        columns_in_buffer = 0
+                        current_line = []
+
+                    columns_in_buffer += width
+                    current_line.append((style, c))
+
+            if len(current_line) > 0:
+                yield current_line
+
+    def _print_paginated_formatted_text(
+        self, lines: Iterable[StyleAndTextTuples]
+    ) -> None:
+        """
+        Print formatted text, using --MORE-- style pagination.
+        (Avoid filling up the terminal's scrollback buffer.)
+        """
+        lines = self._apply_soft_wrapping(lines)
+        pager_prompt = create_pager_prompt(
+            self.style, self.title, output=self.output, input=self.input
+        )
+
+        abort = False
+        print_all = False
+
+        # Max number of lines allowed in the buffer before painting.
+        size = self.output.get_size()
+        max_rows = size.rows - 1
+
+        # Page buffer.
+        page: StyleAndTextTuples = []
+
+        def show_pager() -> None:
+            nonlocal abort, max_rows, print_all
+
+            # Run pager prompt in another thread.
+            # Same as for the input. This prevents issues with nested event
+            # loops.
+            pager_result = pager_prompt.prompt(in_thread=True)
+
+            if pager_result == PagerResult.ABORT:
+                print("...")
+                abort = True
+
+            elif pager_result == PagerResult.NEXT_LINE:
+                max_rows = 1
+
+            elif pager_result == PagerResult.NEXT_PAGE:
+                max_rows = size.rows - 1
+
+            elif pager_result == PagerResult.PRINT_ALL:
+                print_all = True
+
+        # Loop over lines. Show --MORE-- prompt when page is filled.
+        rows = 0
+
+        for lineno, line in enumerate(lines):
+            page.extend(line)
+            page.append(("", "\n"))
+            rows += 1
+
+            if rows >= max_rows:
+                self._print_formatted_text(page, end="")
+                page = []
+                rows = 0
+
+                if not print_all:
+                    show_pager()
+                    if abort:
+                        return
+
+        self._print_formatted_text(page)
+
+    def _format_exception_output(
+        self, e: BaseException, highlight: bool
+    ) -> Generator[OneStyleAndTextTuple, None, None]:
+        # Instead of just calling ``traceback.format_exc``, we take the
+        # traceback and skip the bottom calls of this framework.
+        t, v, tb = sys.exc_info()
+
+        # Required for pdb.post_mortem() to work.
+        sys.last_type, sys.last_value, sys.last_traceback = t, v, tb
+
+        tblist = list(traceback.extract_tb(tb))
+
+        for line_nr, tb_tuple in enumerate(tblist):
+            if tb_tuple[0] == "<stdin>":
+                tblist = tblist[line_nr:]
+                break
+
+        tb_list = traceback.format_list(tblist)
+        if tb_list:
+            tb_list.insert(0, "Traceback (most recent call last):\n")
+        tb_list.extend(traceback.format_exception_only(t, v))
+
+        tb_str = "".join(tb_list)
+
+        # Format exception and write to output.
+        # (We use the default style. Most other styles result
+        # in unreadable colors for the traceback.)
+        if highlight:
+            for index, tokentype, text in PythonTracebackLexer().get_tokens_unprocessed(
+                tb_str
+            ):
+                yield ("class:" + pygments_token_to_classname(tokentype), text)
+        else:
+            yield ("", tb_str)
+
+
+class PagerResult(Enum):
+    ABORT = "ABORT"
+    NEXT_LINE = "NEXT_LINE"
+    NEXT_PAGE = "NEXT_PAGE"
+    PRINT_ALL = "PRINT_ALL"
+
+
+def create_pager_prompt(
+    style: BaseStyle,
+    title: AnyFormattedText = "",
+    input: Input | None = None,
+    output: Output | None = None,
+) -> PromptSession[PagerResult]:
+    """
+    Create a "--MORE--" prompt for paginated output.
+    """
+    bindings = KeyBindings()
+
+    @bindings.add("enter")
+    @bindings.add("down")
+    def next_line(event: KeyPressEvent) -> None:
+        event.app.exit(result=PagerResult.NEXT_LINE)
+
+    @bindings.add("space")
+    def next_page(event: KeyPressEvent) -> None:
+        event.app.exit(result=PagerResult.NEXT_PAGE)
+
+    @bindings.add("a")
+    def print_all(event: KeyPressEvent) -> None:
+        event.app.exit(result=PagerResult.PRINT_ALL)
+
+    @bindings.add("q")
+    @bindings.add("c-c")
+    @bindings.add("c-d")
+    @bindings.add("escape", eager=True)
+    def no(event: KeyPressEvent) -> None:
+        event.app.exit(result=PagerResult.ABORT)
+
+    @bindings.add("<any>")
+    def _(event: KeyPressEvent) -> None:
+        "Disallow inserting other text."
+        pass
+
+    session: PromptSession[PagerResult] = PromptSession(
+        merge_formatted_text(
+            [
+                title,
+                HTML(
+                    "<status-toolbar>"
+                    "<more> -- MORE -- </more> "
+                    "<key>[Enter]</key> Scroll "
+                    "<key>[Space]</key> Next page "
+                    "<key>[a]</key> Print all "
+                    "<key>[q]</key> Quit "
+                    "</status-toolbar>: "
+                ),
+            ]
+        ),
+        key_bindings=bindings,
+        erase_when_done=True,
+        style=style,
+        input=input,
+        output=output,
+    )
+    return session
+
+
+def _lex_python_result(result: str) -> Generator[tuple[str, str], None, None]:
+    "Return token list for Python string."
+    lexer = PythonLexer()
+    # Use `get_tokens_unprocessed`, so that we get exactly the same string,
+    # without line endings appended. `print_formatted_text` already appends a
+    # line ending, and otherwise we'll have two line endings.
+    tokens = lexer.get_tokens_unprocessed(result)
+
+    for index, tokentype, text in tokens:
+        yield ("class:" + pygments_token_to_classname(tokentype), text)

--- a/ptpython/python_input.py
+++ b/ptpython/python_input.py
@@ -4,7 +4,7 @@ This can be used for creation of Python REPLs.
 """
 from __future__ import annotations
 
-from asyncio import get_event_loop
+from asyncio import get_running_loop
 from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Dict, Generic, Mapping, TypeVar, Union
 
@@ -1010,7 +1010,7 @@ class PythonInput:
         app = self.app
 
         async def on_timeout_task() -> None:
-            loop = get_event_loop()
+            loop = get_running_loop()
 
             # Never run multiple get-signature threads.
             if self._get_signatures_thread_running:

--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -17,33 +17,18 @@ import traceback
 import types
 import warnings
 from dis import COMPILER_FLAG_NAMES
-from enum import Enum
-from typing import Any, Callable, ContextManager
+from typing import Any, Callable, ContextManager, Iterable
 
-from prompt_toolkit.formatted_text import (
-    HTML,
-    AnyFormattedText,
-    FormattedText,
-    PygmentsTokens,
-    StyleAndTextTuples,
-    fragment_list_width,
-    merge_formatted_text,
-    to_formatted_text,
-)
-from prompt_toolkit.formatted_text.utils import fragment_list_to_text, split_lines
-from prompt_toolkit.key_binding import KeyBindings, KeyPressEvent
+from prompt_toolkit.formatted_text import OneStyleAndTextTuple
 from prompt_toolkit.patch_stdout import patch_stdout as patch_stdout_context
 from prompt_toolkit.shortcuts import (
-    PromptSession,
     clear_title,
-    print_formatted_text,
     set_title,
 )
-from prompt_toolkit.styles import BaseStyle
-from prompt_toolkit.utils import DummyContext, get_cwidth
-from pygments.lexers import PythonLexer, PythonTracebackLexer
-from pygments.token import Token
+from prompt_toolkit.utils import DummyContext
+from pygments.lexers import PythonTracebackLexer  # noqa: F401
 
+from .printer import OutputPrinter
 from .python_input import PythonInput
 
 PyCF_ALLOW_TOP_LEVEL_AWAIT: int
@@ -108,7 +93,9 @@ class PythonRepl(PythonInput):
             else:
                 # Print.
                 if result is not None:
-                    self.show_result(result)
+                    self._show_result(result)
+                    if self.insert_blank_line_after_output:
+                        self.app.output.write("\n")
 
                 # Loop.
                 self.current_statement_index += 1
@@ -122,6 +109,24 @@ class PythonRepl(PythonInput):
             # prevent that a Control-C keypress terminates the REPL in
             # any case.)
             self._handle_keyboard_interrupt(e)
+
+    def _get_output_printer(self) -> OutputPrinter:
+        return OutputPrinter(
+            output=self.app.output,
+            input=self.app.input,
+            style=self._current_style,
+            style_transformation=self.style_transformation,
+            title=self.title,
+        )
+
+    def _show_result(self, result: object) -> None:
+        self._get_output_printer().display_result(
+            result=result,
+            out_prompt=self.get_output_prompt(),
+            reformat=self.enable_output_formatting,
+            highlight=self.enable_syntax_highlighting,
+            paginate=self.enable_pager,
+        )
 
     def run(self) -> None:
         """
@@ -167,7 +172,7 @@ class PythonRepl(PythonInput):
         else:
             # Print.
             if result is not None:
-                await loop.run_in_executor(None, lambda: self.show_result(result))
+                await loop.run_in_executor(None, lambda: self._show_result(result))
 
             # Loop.
             self.current_statement_index += 1
@@ -318,264 +323,12 @@ class PythonRepl(PythonInput):
             dont_inherit=True,
         )
 
-    def _format_result_output(self, result: object) -> StyleAndTextTuples:
-        """
-        Format __repr__ for an `eval` result.
-
-        Note: this can raise `KeyboardInterrupt` if either calling `__repr__`,
-              `__pt_repr__` or formatting the output with "Black" takes to long
-              and the user presses Control-C.
-        """
-        out_prompt = to_formatted_text(self.get_output_prompt())
-
-        # If the repr is valid Python code, use the Pygments lexer.
-        try:
-            result_repr = repr(result)
-        except KeyboardInterrupt:
-            raise  # Don't catch here.
-        except BaseException as e:
-            # Calling repr failed.
-            self._handle_exception(e)
-            return []
-
-        try:
-            compile(result_repr, "", "eval")
-        except SyntaxError:
-            formatted_result_repr = to_formatted_text(result_repr)
-        else:
-            # Syntactically correct. Format with black and syntax highlight.
-            if self.enable_output_formatting:
-                # Inline import. Slightly speed up start-up time if black is
-                # not used.
-                try:
-                    import black
-
-                    if not hasattr(black, "Mode"):
-                        raise ImportError
-                except ImportError:
-                    pass  # no Black package in your installation
-                else:
-                    result_repr = black.format_str(
-                        result_repr,
-                        mode=black.Mode(line_length=self.app.output.get_size().columns),
-                    )
-
-            formatted_result_repr = to_formatted_text(
-                PygmentsTokens(list(_lex_python_result(result_repr)))
-            )
-
-        # If __pt_repr__ is present, take this. This can return prompt_toolkit
-        # formatted text.
-        try:
-            if hasattr(result, "__pt_repr__"):
-                formatted_result_repr = to_formatted_text(
-                    getattr(result, "__pt_repr__")()
-                )
-                if isinstance(formatted_result_repr, list):
-                    formatted_result_repr = FormattedText(formatted_result_repr)
-        except KeyboardInterrupt:
-            raise  # Don't catch here.
-        except:
-            # For bad code, `__getattr__` can raise something that's not an
-            # `AttributeError`. This happens already when calling `hasattr()`.
-            pass
-
-        # Align every line to the prompt.
-        line_sep = "\n" + " " * fragment_list_width(out_prompt)
-        indented_repr: StyleAndTextTuples = []
-
-        lines = list(split_lines(formatted_result_repr))
-
-        for i, fragment in enumerate(lines):
-            indented_repr.extend(fragment)
-
-            # Add indentation separator between lines, not after the last line.
-            if i != len(lines) - 1:
-                indented_repr.append(("", line_sep))
-
-        # Write output tokens.
-        if self.enable_syntax_highlighting:
-            formatted_output = merge_formatted_text([out_prompt, indented_repr])
-        else:
-            formatted_output = FormattedText(
-                out_prompt + [("", fragment_list_to_text(formatted_result_repr))]
-            )
-
-        return to_formatted_text(formatted_output)
-
-    def show_result(self, result: object) -> None:
-        """
-        Show __repr__ for an `eval` result and print to output.
-        """
-        formatted_text_output = self._format_result_output(result)
-
-        if self.enable_pager:
-            self.print_paginated_formatted_text(formatted_text_output)
-        else:
-            self.print_formatted_text(formatted_text_output)
-
-        self.app.output.flush()
-
-        if self.insert_blank_line_after_output:
-            self.app.output.write("\n")
-
-    def print_formatted_text(
-        self, formatted_text: StyleAndTextTuples, end: str = "\n"
-    ) -> None:
-        print_formatted_text(
-            FormattedText(formatted_text),
-            style=self._current_style,
-            style_transformation=self.style_transformation,
-            include_default_pygments_style=False,
-            output=self.app.output,
-            end=end,
-        )
-
-    def print_paginated_formatted_text(
-        self,
-        formatted_text: StyleAndTextTuples,
-        end: str = "\n",
-    ) -> None:
-        """
-        Print formatted text, using --MORE-- style pagination.
-        (Avoid filling up the terminal's scrollback buffer.)
-        """
-        pager_prompt = self.create_pager_prompt()
-        size = self.app.output.get_size()
-
-        abort = False
-        print_all = False
-
-        # Max number of lines allowed in the buffer before painting.
-        max_rows = size.rows - 1
-
-        # Page buffer.
-        rows_in_buffer = 0
-        columns_in_buffer = 0
-        page: StyleAndTextTuples = []
-
-        def flush_page() -> None:
-            nonlocal page, columns_in_buffer, rows_in_buffer
-            self.print_formatted_text(page, end="")
-            page = []
-            columns_in_buffer = 0
-            rows_in_buffer = 0
-
-        def show_pager() -> None:
-            nonlocal abort, max_rows, print_all
-
-            # Run pager prompt in another thread.
-            # Same as for the input. This prevents issues with nested event
-            # loops.
-            pager_result = pager_prompt.prompt(in_thread=True)
-
-            if pager_result == PagerResult.ABORT:
-                print("...")
-                abort = True
-
-            elif pager_result == PagerResult.NEXT_LINE:
-                max_rows = 1
-
-            elif pager_result == PagerResult.NEXT_PAGE:
-                max_rows = size.rows - 1
-
-            elif pager_result == PagerResult.PRINT_ALL:
-                print_all = True
-
-        # Loop over lines. Show --MORE-- prompt when page is filled.
-
-        formatted_text = formatted_text + [("", end)]
-        lines = list(split_lines(formatted_text))
-
-        for lineno, line in enumerate(lines):
-            for style, text, *_ in line:
-                for c in text:
-                    width = get_cwidth(c)
-
-                    # (Soft) wrap line if it doesn't fit.
-                    if columns_in_buffer + width > size.columns:
-                        # Show pager first if we get too many lines after
-                        # wrapping.
-                        if rows_in_buffer + 1 >= max_rows and not print_all:
-                            page.append(("", "\n"))
-                            flush_page()
-                            show_pager()
-                            if abort:
-                                return
-
-                        rows_in_buffer += 1
-                        columns_in_buffer = 0
-
-                    columns_in_buffer += width
-                    page.append((style, c))
-
-            if rows_in_buffer + 1 >= max_rows and not print_all:
-                page.append(("", "\n"))
-                flush_page()
-                show_pager()
-                if abort:
-                    return
-            else:
-                # Add line ending between lines (if `end="\n"` was given, one
-                # more empty line is added in `split_lines` automatically to
-                # take care of the final line ending).
-                if lineno != len(lines) - 1:
-                    page.append(("", "\n"))
-                    rows_in_buffer += 1
-                    columns_in_buffer = 0
-
-        flush_page()
-
-    def create_pager_prompt(self) -> PromptSession[PagerResult]:
-        """
-        Create pager --MORE-- prompt.
-        """
-        return create_pager_prompt(self._current_style, self.title)
-
-    def _format_exception_output(self, e: BaseException) -> PygmentsTokens:
-        # Instead of just calling ``traceback.format_exc``, we take the
-        # traceback and skip the bottom calls of this framework.
-        t, v, tb = sys.exc_info()
-
-        # Required for pdb.post_mortem() to work.
-        sys.last_type, sys.last_value, sys.last_traceback = t, v, tb
-
-        tblist = list(traceback.extract_tb(tb))
-
-        for line_nr, tb_tuple in enumerate(tblist):
-            if tb_tuple[0] == "<stdin>":
-                tblist = tblist[line_nr:]
-                break
-
-        tb_list = traceback.format_list(tblist)
-        if tb_list:
-            tb_list.insert(0, "Traceback (most recent call last):\n")
-        tb_list.extend(traceback.format_exception_only(t, v))
-
-        tb_str = "".join(tb_list)
-
-        # Format exception and write to output.
-        # (We use the default style. Most other styles result
-        # in unreadable colors for the traceback.)
-        if self.enable_syntax_highlighting:
-            tokens = list(_lex_python_traceback(tb_str))
-        else:
-            tokens = [(Token, tb_str)]
-        return PygmentsTokens(tokens)
-
     def _handle_exception(self, e: BaseException) -> None:
-        output = self.app.output
-
-        tokens = self._format_exception_output(e)
-
-        print_formatted_text(
-            tokens,
-            style=self._current_style,
-            style_transformation=self.style_transformation,
-            include_default_pygments_style=False,
-            output=output,
+        self._get_output_printer().display_exception(
+            e,
+            highlight=self.enable_syntax_highlighting,
+            paginate=self.enable_pager,
         )
-        output.flush()
 
     def _handle_keyboard_interrupt(self, e: KeyboardInterrupt) -> None:
         output = self.app.output
@@ -602,21 +355,16 @@ class PythonRepl(PythonInput):
         globals = self.get_globals()
         del globals["get_ptpython"]
 
-
-def _lex_python_traceback(tb):
-    "Return token list for traceback string."
-    lexer = PythonTracebackLexer()
-    return lexer.get_tokens(tb)
-
-
-def _lex_python_result(tb):
-    "Return token list for Python string."
-    lexer = PythonLexer()
-    # Use `get_tokens_unprocessed`, so that we get exactly the same string,
-    # without line endings appended. `print_formatted_text` already appends a
-    # line ending, and otherwise we'll have two line endings.
-    tokens = lexer.get_tokens_unprocessed(tb)
-    return [(tokentype, value) for index, tokentype, value in tokens]
+    def print_paginated_formatted_text(
+        self,
+        formatted_text: Iterable[OneStyleAndTextTuple],
+        end: str = "\n",
+    ) -> None:
+        # Warning: This is mainly here backwards-compatibility. Some projects
+        # call `print_paginated_formatted_text` on the Repl object.
+        self._get_output_printer().display_style_and_text_tuples(
+            formatted_text, paginate=True
+        )
 
 
 def enable_deprecation_warnings() -> None:
@@ -746,67 +494,3 @@ def embed(
     else:
         with patch_context:
             repl.run()
-
-
-class PagerResult(Enum):
-    ABORT = "ABORT"
-    NEXT_LINE = "NEXT_LINE"
-    NEXT_PAGE = "NEXT_PAGE"
-    PRINT_ALL = "PRINT_ALL"
-
-
-def create_pager_prompt(
-    style: BaseStyle, title: AnyFormattedText = ""
-) -> PromptSession[PagerResult]:
-    """
-    Create a "continue" prompt for paginated output.
-    """
-    bindings = KeyBindings()
-
-    @bindings.add("enter")
-    @bindings.add("down")
-    def next_line(event: KeyPressEvent) -> None:
-        event.app.exit(result=PagerResult.NEXT_LINE)
-
-    @bindings.add("space")
-    def next_page(event: KeyPressEvent) -> None:
-        event.app.exit(result=PagerResult.NEXT_PAGE)
-
-    @bindings.add("a")
-    def print_all(event: KeyPressEvent) -> None:
-        event.app.exit(result=PagerResult.PRINT_ALL)
-
-    @bindings.add("q")
-    @bindings.add("c-c")
-    @bindings.add("c-d")
-    @bindings.add("escape", eager=True)
-    def no(event: KeyPressEvent) -> None:
-        event.app.exit(result=PagerResult.ABORT)
-
-    @bindings.add("<any>")
-    def _(event: KeyPressEvent) -> None:
-        "Disallow inserting other text."
-        pass
-
-    style
-
-    session: PromptSession[PagerResult] = PromptSession(
-        merge_formatted_text(
-            [
-                title,
-                HTML(
-                    "<status-toolbar>"
-                    "<more> -- MORE -- </more> "
-                    "<key>[Enter]</key> Scroll "
-                    "<key>[Space]</key> Next page "
-                    "<key>[a]</key> Print all "
-                    "<key>[q]</key> Quit "
-                    "</status-toolbar>: "
-                ),
-            ]
-        ),
-        key_bindings=bindings,
-        erase_when_done=True,
-        style=style,
-    )
-    return session

--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -158,7 +158,7 @@ class PythonRepl(PythonInput):
                 clear_title()
             self._remove_from_namespace()
 
-    async def run_and_show_expression_async(self, text: str):
+    async def run_and_show_expression_async(self, text: str) -> object:
         loop = asyncio.get_event_loop()
 
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ ignore = [
 "ptpython/entry_points/run_ptpython.py" = ["T201"]  # Print usage.
 "ptpython/ipython.py" = ["T100"]  # Import usage.
 "ptpython/repl.py" = ["T201"]  # Print usage.
+"ptpython/printer.py" = ["T201"]  # Print usage.
 "tests/run_tests.py" = ["F401"]  # Unused imports.
 
 


### PR DESCRIPTION
Previously, an expression like `b'\x90' * 40_000_000` would kill ptpython because it rendered the whole output at once. This implementation streams the rendering logic while it's paginating.

This PR also contains typing fixes as well as asyncio-related improvements (in separate commits).