### PR TITLE
docs(README): Fix PyPI and CI buttons

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -294,6 +294,6 @@ Special thanks to
 .. |License| image:: https://img.shields.io/github/license/prompt-toolkit/ptpython.svg
     :target: https://github.com/prompt-toolkit/ptpython/blob/master/LICENSE
 
-.. |PyPI| image:: https://pypip.in/version/ptpython/badge.svg
-    :target: https://pypi.python.org/pypi/ptpython/
+.. |PyPI| image:: https://img.shields.io/pypi/v/ptpython.svg
+    :target: https://pypi.org/project/ptpython/
     :alt: Latest Version

--- a/README.rst
+++ b/README.rst
@@ -288,8 +288,8 @@ Special thanks to
 - `wcwidth <https://github.com/jquast/wcwidth>`_: Determine columns needed for a wide characters.
 - `prompt_toolkit <http://github.com/jonathanslenders/python-prompt-toolkit>`_ for the interface.
 
-.. |Build Status| image:: https://api.travis-ci.org/prompt-toolkit/ptpython.svg?branch=master
-    :target: https://travis-ci.org/prompt-toolkit/ptpython#
+.. |Build Status| image:: https://github.com/prompt-toolkit/ptpython/actions/workflows/test.yaml/badge.svg
+    :target: https://github.com/prompt-toolkit/ptpython/actions/workflows/test.yaml
 
 .. |License| image:: https://img.shields.io/github/license/prompt-toolkit/ptpython.svg
     :target: https://github.com/prompt-toolkit/ptpython/blob/master/LICENSE


### PR DESCRIPTION
Resolves #556

# Changes

## As-is (master @ 1a96f0e)

![image](https://github.com/prompt-toolkit/ptpython/assets/26336/c2409c26-5420-44b3-9810-4a02d7ad6907)

Aside / bikeshed: As of very recently, repo home pages now show the license above where the README is.

## With PR

![image](https://github.com/prompt-toolkit/ptpython/assets/26336/18ac6270-6987-4fd9-841b-053db9958c72)