### PR TITLE
Package: Add PyPI Links to repo, issues, and changelog

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,14 @@ setup(
     url="https://github.com/prompt-toolkit/ptpython",
     description="Python REPL build on top of prompt_toolkit",
     long_description=long_description,
+    package_urls={
+        "Changelog": "https://github.com/prompt-toolkit/ptpython/blob/master/CHANGELOG",
+    },
+    project_urls={
+        "Bug Tracker": "https://github.com/prompt-toolkit/ptpython/issues",
+        "Source Code": "https://github.com/prompt-toolkit/ptpython",
+        "Changelog": "https://github.com/prompt-toolkit/ptpython/blob/master/CHANGELOG",
+    },
     packages=find_packages("."),
     package_data={"ptpython": ["py.typed"]},
     install_requires=[


### PR DESCRIPTION
This will add PyPI links to https://pypi.org/project/ptpython/ after deployed:

![image](https://github.com/prompt-toolkit/ptpython/assets/26336/2512b18b-fdfc-4637-8f6b-e19a24352ecf)
