### PR TITLE
Reraise GeneratorExit error as excepted exception

### DIFF
--- a/ptpython/printer.py
+++ b/ptpython/printer.py
@@ -155,7 +155,7 @@ class OutputPrinter:
                 )
                 yield from formatted_result_repr
                 return
-        except KeyboardInterrupt:
+        except (GeneratorExit, KeyboardInterrupt):
             raise  # Don't catch here.
         except:
             # For bad code, `__getattr__` can raise something that's not an


### PR DESCRIPTION
Solves the RuntimeError that pops when the generator is exited