### PR TITLE
Use sys.displayhook for converting result to string

### DIFF
--- a/ptpython/printer.py
+++ b/ptpython/printer.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import sys
 import traceback
+from contextlib import redirect_stdout
 from dataclasses import dataclass
 from enum import Enum
+from io import StringIO
 from typing import Generator, Iterable
 
 from prompt_toolkit.formatted_text import (
@@ -164,7 +166,10 @@ class OutputPrinter:
 
         # Call `__repr__` of given object first, to turn it in a string.
         try:
-            result_repr = repr(result)
+            result_repr_sio = StringIO()
+            with redirect_stdout(result_repr_sio):
+                sys.displayhook(result)
+            result_repr = result_repr_sio.getvalue()[:-1]  # Remove '\n' at the end
         except KeyboardInterrupt:
             raise  # Don't catch here.
         except BaseException as e:


### PR DESCRIPTION
Fix for #488 

Some libraries, like SymPy, redefine `sys.displayhook` to change printing behavior. 

Use `sys.displayhook` to convert the result to a string in `OutputPrinter._format_result_output`.





