### PR TITLE
Update supported  versions on README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ ptpython
 .. image :: https://github.com/jonathanslenders/ptpython/raw/master/docs/images/example1.png
 
 Ptpython is an advanced Python REPL. It should work on all
-Python versions from 2.6 up to 3.9 and work cross platform (Linux,
+Python versions from 2.6 up to 3.11 and work cross platform (Linux,
 BSD, OS X and Windows).
 
 Note: this version of ptpython requires at least Python 3.6. Install ptpython


### PR DESCRIPTION
I saw that `.github/workflows/test.yml` actually tests up to 3.11 - so I think this just hasn't been updated in the README?

Apologies if I'm wrong and there's another way of testing that doesn't cover 3.10 and 3.11!