### PR TITLE
display autocompletion menu on backspace too, similar to how IDEs' autocomplete behaves

### DIFF
--- a/ptpython/key_bindings.py
+++ b/ptpython/key_bindings.py
@@ -217,6 +217,14 @@ def load_python_bindings(python_input: PythonInput) -> KeyBindings:
         "Abort when Control-C has been pressed."
         event.app.exit(exception=KeyboardInterrupt, style="class:aborting")
 
+    @handle("backspace", filter=(vi_insert_mode | emacs_insert_mode))
+    def _(event: E) -> None:
+        """
+        Display autocomplete menu on backspace
+        """
+        get_by_name("backward-delete-char").call(event)
+        event.current_buffer.start_completion(select_first=False)
+
     return bindings
 
 


### PR DESCRIPTION
fixes #583 

before:

https://github.com/prompt-toolkit/ptpython/assets/9993663/fbd46793-9763-4008-a8f2-11136c6f4dc8


after:

https://github.com/prompt-toolkit/ptpython/assets/9993663/58d304ad-d762-47db-a8e0-36a4380a42b5

