### PR TITLE
Clean up signatures on ctrl-c

### DIFF
--- a/ptpython/python_input.py
+++ b/ptpython/python_input.py
@@ -1116,4 +1116,5 @@ class PythonInput:
                     return result
             except KeyboardInterrupt:
                 # Abort - try again.
+                self.signatures = []
                 self.default_buffer.document = Document()


### PR DESCRIPTION
If `show signature` option is enable, a ctrl-c during the display of such signature is not cleaned up.

See the following screenshot.

![image](https://github.com/prompt-toolkit/ptpython/assets/7579321/a33cbe19-1ed6-408e-b100-6652112d7f2b)

This PR clear the `self.signatures` before clearing the document.