### PR TITLE
Custom exit function

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Type Checker
         run: |
           mypy ptpython
-          ruff .
+          ruff check .
           ruff format --check .
       - name: Run Tests
         run: |


### PR DESCRIPTION
- Don't terminate `sys.stdin` when `exit` is called (important for `embed()`).
- Don't require 'exit' to be called with parentheses.