### PR TITLE
Pass style with meta completion text

### DIFF
--- a/ptpython/completer.py
+++ b/ptpython/completer.py
@@ -285,12 +285,15 @@ class JediCompleter(Completer):
                     if jc.type == "param":
                         suffix = "..."
 
+                    style = _get_style_for_jedi_completion(jc)
+                    display_meta = jc.type if style == "" else [(style, jc.type)]
+
                     yield Completion(
                         jc.name_with_symbols,
                         len(jc.complete) - len(jc.name_with_symbols),
                         display=jc.name_with_symbols + suffix,
-                        display_meta=jc.type,
-                        style=_get_style_for_jedi_completion(jc),
+                        display_meta=display_meta,
+                        style=style,
                     )
 
 


### PR DESCRIPTION
Hi there! I love ptpython, love that users can style it, and am hoping you'll consider a small PR to facilitate that.

The `completion-menu.completion` and `completion-menu.meta.completion` appear to be siblings of each other, so there's no way to style the meta menu based on the type of completion. I personally find it much easier to read if the type is colored, but the completion element is always a consistent style, and this enables that. Here is an example:

![CleanShot 2024-07-22 at 23 02 44@2x](https://github.com/user-attachments/assets/769bb78b-f590-4df6-9074-9fb55188a946)

Ignore the `class` there: I modified the types returned as well when I noticed that jedi returns several more options than the three (builtin, param, keyword) that ptpython currently maps to. I have not included that change in this PR. I would be happy to submit another PR for that if it would be welcome.

Thanks for considering!
