### PR TITLE
Fix repl.min_brightness and repl.max_brightness config not work in history

### DIFF
--- a/src/ptpython/history_browser.py
+++ b/src/ptpython/history_browser.py
@@ -643,6 +643,7 @@ class PythonHistory:
             layout=self.history_layout.layout,
             full_screen=True,
             style=python_input._current_style,
+            style_transformation=python_input.style_transformation,
             mouse_support=Condition(lambda: python_input.enable_mouse_support),
             key_bindings=create_key_bindings(self, python_input, history_mapping),
         )


### PR DESCRIPTION
This pull request fix that inconsistence style between history and repl when user set `repl.min_brightness` or `repl.max_brightness` in `~/.config/ptpython/config.py`