### PR TITLE
Add wrap_lines to docstrings window

### DIFF
--- a/src/ptpython/layout.py
+++ b/src/ptpython/layout.py
@@ -741,6 +741,7 @@ class PtPythonLayout:
                                             # lexer=PythonLexer,
                                         ),
                                         height=D(max=12),
+                                        wrap_lines=True,
                                     ),
                                     filter=HasSignature(python_input)
                                     & ShowDocstring(python_input)


### PR DESCRIPTION
Before: docstrings can be cut off if they're longer than the window
<img width="914" height="358" alt="Screenshot 2025-12-01 at 2 01 53 AM" src="https://github.com/user-attachments/assets/cd43152b-7159-4089-b697-94d15c8fea36" />

After: docstrings will wrap to fit in the available space
<img width="895" height="331" alt="Screenshot 2025-12-01 at 2 02 15 AM" src="https://github.com/user-attachments/assets/022d194b-c593-4114-beb0-679a6877b27c" />
