### PR TITLE
Only display exception context if __suppress_context__ not set

### DIFF
--- a/src/ptpython/printer.py
+++ b/src/ptpython/printer.py
@@ -327,7 +327,7 @@ class OutputPrinter:
                 "",
                 "\nThe above exception was the direct cause of the following exception:\n\n",
             )
-        elif e.__context__:
+        elif e.__context__ and not e.__suppress_context__:
             yield from self._format_exception_output(e.__context__, highlight=highlight)
             yield (
                 "",


### PR DESCRIPTION
The built-in repl only displays the context of an exception (the "During
the handling of the above exception..." message) if `__suppress_context__`
is not set, eg by using

    raise Exception() from xyz

This makes ptpython behave the same way.

See description of default behaviour in the python docs:

    https://docs.python.org/3/library/exceptions.html#BaseException.__suppress_context__
